### PR TITLE
Space is now slightly darker.

### DIFF
--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -20,7 +20,7 @@
 /area/space/Initialize(mapload)
 	. = ..()
 
-	add_overlay(GLOB.fullbright_overlay)
+	add_overlay(GLOB.space_overlay)
 
 /area/space/nearstation
 	icon_state = "space_near"

--- a/code/modules/lighting/space_area_lights.dm
+++ b/code/modules/lighting/space_area_lights.dm
@@ -1,0 +1,16 @@
+//Engage Copypasta
+GLOBAL_DATUM_INIT(space_overlay, /mutable_appearance, create_space_overlay())
+
+/proc/create_space_overlay()
+	var/mutable_appearance/lighting_effect = mutable_appearance('icons/effects/alphacolors.dmi')
+	lighting_effect.plane = LIGHTING_PLANE
+	lighting_effect.layer = LIGHTING_PRIMARY_LAYER
+	lighting_effect.blend_mode = BLEND_ADD
+	lighting_effect.alpha = 160
+	return lighting_effect
+
+
+//Non static lighting areas.
+//Any lighting area that wont support static lights.
+//These areas will NOT have corners generated.
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3323,6 +3323,7 @@
 #include "code\modules\lighting\lighting_setup.dm"
 #include "code\modules\lighting\lighting_source.dm"
 #include "code\modules\lighting\lighting_turf.dm"
+#include "code\modules\lighting\space_area_lights.dm"
 #include "code\modules\lighting\static_lighting_area.dm"
 #include "code\modules\mafia\_defines.dm"
 #include "code\modules\mafia\controller.dm"


### PR DESCRIPTION
## About The Pull Request

Makes space slightly darker. 
![dreamseeker_mDxT4Swu8P](https://user-images.githubusercontent.com/77420409/220505172-0eb6dfd3-980b-48fe-b98f-8edd33d99934.png)
![dreamseeker_GBVy1JHLXb](https://user-images.githubusercontent.com/77420409/220505176-1e94f2db-aa8a-497c-bc40-8a71430bda84.png)



## How Does This Help ***Gameplay***?

It feels cozier and less full bright. 
## How Does This Help ***Roleplay***?

It does not, probably. 


## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: Space has been made darker. 
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
