### PR TITLE
Fixes Split personality Ghosting its owner if cured ina wrong moment

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -58,13 +58,6 @@
 	QDEL_NULL(owner_backseat)
 	..()
 
-/datum/brain_trauma/severe/split_personality/Destroy()
-	if(stranger_backseat)
-		QDEL_NULL(stranger_backseat)
-	if(owner_backseat)
-		QDEL_NULL(owner_backseat)
-	return ..()
-
 /datum/brain_trauma/severe/split_personality/proc/switch_personalities(reset_to_owner = FALSE)
 	if(QDELETED(owner) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
 		return


### PR DESCRIPTION
## About The Pull Request
Yoinked this fix from TG https://github.com/tgstation/tgstation/pull/73579 and because its on the list of stuff we want ported.

(Fixes the bug that caused split personality to put the second personality in permament control if cured when it was in control. The problem was apparently that destroy() is called before on_lose(), which first deleted the mobs housing second personality, and then tried to swap the original owner back, which failed.)

## How Does This Help ***Gameplay***?
Bugs bad and stuff should work properly :P

## How Does This Help ***Roleplay***?
stuff breaking and not working properly breaks muh immersion.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> 

![istockphoto-91520053-612x612](https://user-images.githubusercontent.com/79924768/222978273-8040b9e9-e950-47e1-a43f-b65eea3adef4.jpg)

</details>

## Changelog

:cl:
fix: Fixes split personality kicking out the original owner of the body.
/:cl: