### PR TITLE
Walls are named based on their materials.

### DIFF
--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -49,13 +49,15 @@ Simple datum which is instanced once per type and is used for every object of sa
 	///Icon for walls which are plated with this material
 	var/wall_greyscale_config = /datum/greyscale_config/solid_wall
 	///Icon for reinforced walls which are plated with this material
-	var/reinforced_wall_greyscale_config = /datum/greyscale_config/reinforced_solid_wall
+	var/reinforced_wall_greyscale_config = /datum/greyscale_config/metal_wall
 	/// Icon for painted stripes on the walls
 	var/wall_stripe_greyscale_config = /datum/greyscale_config/wall_stripe
 	/// Color of walls constructed with this material as their plating
 	var/wall_color
 	/// Type of the wall this material makes when its used as a plating, null means can't make a wall out of it.
 	var/wall_type = /turf/closed/wall
+	/// What do we *call* a 'wall' made out of this stuff?
+	var/wall_name = "wall"
 	/// Type of the false wall this material will make when used as its plating
 	var/false_wall_type
 	/// If true, walls plated with this material that have a reinforcement, will be hard to deconstruct

--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -40,6 +40,11 @@
 	sheet_type = /obj/item/stack/sheet/plasteel
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/iron=1, /datum/material/plasma=1)
+	reinforced_wall_greyscale_config = /datum/greyscale_config/reinforced_solid_wall
+	//This creates legacy r_walls so that I don't have to recode a shitload of stuff
+	wall_type = /turf/closed/wall/r_wall
+	false_wall_type = /obj/structure/falsewall/reinforced
+	wall_name = "bulkhead"
 	wall_color = "#57575c"
 	hard_wall_decon = TRUE
 
@@ -76,6 +81,7 @@
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/titanium=1, /datum/material/plasma=1)
 	wall_greyscale_config = /datum/greyscale_config/metal_wall
+	reinforced_wall_greyscale_config = /datum/greyscale_config/reinforced_solid_wall
 	wall_type = /turf/closed/wall/mineral/plastitanium
 	false_wall_type = /obj/structure/falsewall/plastitanium
 	hard_wall_decon = TRUE
@@ -158,6 +164,8 @@
 	value_per_unit = 0.4
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/iron=2, /datum/material/plasma=2)
+	reinforced_wall_greyscale_config = /datum/greyscale_config/reinforced_solid_wall
+	wall_name = "hull"
 	hard_wall_decon = TRUE
 
 /datum/material/alloy/alien/on_applied_obj(obj/item/target_item, amount, material_flags)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -104,6 +104,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.05
 	beauty_modifier = 0.3 //It shines so beautiful
 	armor_modifiers = list(MELEE = 1.5, BULLET = 1.4, LASER = 0.5, ENERGY = 0.5, BOMB = 0, BIO = 0, FIRE = 1, ACID = 1)
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 	wall_type = /turf/closed/wall/mineral/uranium
 	false_wall_type = /obj/structure/falsewall/uranium
 
@@ -141,6 +142,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.1
 	beauty_modifier = 0.15
 	armor_modifiers = list(MELEE = 1.4, BULLET = 0.7, LASER = 0, ENERGY = 1.2, BOMB = 0, BIO = 1.2, FIRE = 0, ACID = 0.5)
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 	wall_type = /turf/closed/wall/mineral/plasma
 	false_wall_type = /obj/structure/falsewall/plasma
 
@@ -192,6 +194,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.5
 	beauty_modifier = 0.5
 	armor_modifiers = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 100, BIO = 0, FIRE = 10, ACID = 0) //Clowns cant be blown away.
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 	wall_type = /turf/closed/wall/mineral/bananium
 	false_wall_type = /obj/structure/falsewall/bananium
 
@@ -320,6 +323,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.25
 	beauty_modifier = 0.4
 	armor_modifiers = list(MELEE = 1.5, BULLET = 1.5, LASER = 1.3, ENERGY = 1.3, BOMB = 1, BIO = 1, FIRE = 2.5, ACID = 1)
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 
 /datum/material/adamantine/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.apply_damage(20, BRUTE, BODY_ZONE_HEAD, wound_bonus = 10)
@@ -337,6 +341,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	strength_modifier = 1.2
 	armor_modifiers = list(MELEE = 1.5, BULLET = 1.5, LASER = 1.5, ENERGY = 1.5, BOMB = 1.5, BIO = 1.5, FIRE = 1.5, ACID = 1.5)
 	beauty_modifier = 0.5
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 
 /datum/material/mythril/on_applied_obj(atom/source, amount, material_flags)
 	. = ..()
@@ -409,6 +414,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.25
 	turf_sound_override = FOOTSTEP_SAND
 	texture_layer_icon_state = "sand"
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 
 /datum/material/sand/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.adjust_disgust(17)
@@ -509,6 +515,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.003
 	armor_modifiers = list(MELEE = 0.25, BULLET = 0.25, LASER = 0.25, ENERGY = 0.25, BOMB = 0.25, BIO = 0.25, FIRE = 0, ACID = 1.5)
 	beauty_modifier = -0.1
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 
 /datum/material/cardboard/on_applied_obj(obj/source, amount, material_flags)
 	. = ..()

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -30,13 +30,16 @@
 	/// Stripe paint of the wall
 	var/stripe_paint
 	var/opening = FALSE
+	/// Material Set Name
+	var/matset_name
 
 	/// Typecache of the neighboring objects that we want to neighbor stripe overlay with
 	var/static/list/neighbor_typecache
 
 /obj/structure/falsewall/Initialize()
+	color = null //Clear the mapaid color. This should hopefully not cause problems.
+	//This has to be stripped before the supercall so it doesn't end up in atom_colours.
 	. = ..()
-	color = null //Clear the color that's a mapping aid
 	air_update_turf(TRUE, TRUE)
 	set_wall_information(plating_material, reinf_material, wall_paint, stripe_paint)
 
@@ -59,10 +62,7 @@
 
 /obj/structure/falsewall/update_name()
 	. = ..()
-	if(reinf_material)
-		name = "reinforced wall"
-	else
-		name = "wall"
+	name = matset_name
 
 /obj/structure/falsewall/attack_hand(mob/user, list/modifiers)
 	if(opening)
@@ -188,7 +188,7 @@
 	stripe_paint = new_stripe_paint
 	set_materials(plating_mat, reinf_mat)
 
-/// Painfully copypasted from /turf/closed/wall
+/// Painfully copypasted from /turf/closed/wall (Twice!)
 /obj/structure/falsewall/proc/set_materials(plating_mat, reinf_mat)
 	var/datum/material/plating_mat_ref
 	if(plating_mat)
@@ -204,6 +204,14 @@
 
 	plating_material = plating_mat
 	reinf_material = reinf_mat
+
+	if(reinf_material)
+		name = "reinforced [plating_mat_ref.name] [plating_mat_ref.wall_name]"
+		desc = "It seems to be a section of hull reinforced with [reinf_mat_ref.name] and plated with [plating_mat_ref.name]."
+	else
+		name = "[plating_mat_ref.name] [plating_mat_ref.wall_name]"
+		desc = "It seems to be a section of hull plated with [plating_mat_ref.name]."
+	matset_name = name
 
 	update_greyscale()
 	update_appearance()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -119,6 +119,12 @@
 			to_chat(user, span_warning("You need two sheets of [S]!"))
 			return
 		if(state == GIRDER_REINF_STRUTS)
+			//Let's just prevent you from reinforcing with anything that wouldn't already make a wall
+			var/datum/material/reinf_mat_ref = GET_MATERIAL_REF(S.material_type)
+			var/wall_type = reinf_mat_ref.wall_type
+			if(!wall_type)
+				to_chat(user, span_warning("You can't figure out how to reinforce a wall with this!"))
+				return
 			to_chat(user, span_notice("You start reinforcing the girder..."))
 			if(do_after(user, 20*platingmodifier, target = src))
 				if(state != GIRDER_REINF_STRUTS)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -43,6 +43,8 @@
 	var/d_state = INTACT
 	/// Whether this wall is rusted or not, to apply the rusted overlay
 	var/rusted
+	/// Material Set Name
+	var/matset_name
 
 	var/list/dent_decals
 
@@ -75,13 +77,10 @@
 
 /turf/closed/wall/update_name()
 	. = ..()
-	name = ""
 	if(rusted)
-		name = "rusted "
-	if(reinf_material)
-		name += "reinforced wall"
+		name = "rusted "+ matset_name
 	else
-		name += "wall"
+		name = matset_name
 
 /turf/closed/wall/Initialize(mapload)
 	. = ..()
@@ -219,6 +218,13 @@
 	plating_material = plating_mat
 	reinf_material = reinf_mat
 
+	if(reinf_material)
+		name = "reinforced [plating_mat_ref.name] [plating_mat_ref.wall_name]"
+		desc = "It seems to be a section of hull reinforced with [reinf_mat_ref.name] and plated with [plating_mat_ref.name]."
+	else
+		name = "[plating_mat_ref.name] [plating_mat_ref.wall_name]"
+		desc = "It seems to be a section of hull plated with [plating_mat_ref.name]."
+	matset_name = name
 	update_greyscale()
 	update_appearance()
 


### PR DESCRIPTION
## About The Pull Request
Ported from: https://github.com/DaedalusDock/daedalusdock/pull/69 Makes walls use the name of the materials used in construction

## How Does This Help ***Gameplay***?
Funny new wall names so everything isn't named *wall* (minimal impact otherwise)

## How Does This Help ***Roleplay***?
Minimal impact on roleplay tbh

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

### Normal walls
![](https://i.gyazo.com/6d757406ba24ac996ca44b2c4c752f10.png)

### Reinforced walls 
![](https://i.gyazo.com/ed9c43ebff69864e94c2206fed98649c.png)


</details>

## Changelog

:cl:
qol: 
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
