### PR TITLE
Disables the tab hotkey for switching say mode

### DIFF
--- a/tgui/packages/tgui-say/handlers/keyDown.tsx
+++ b/tgui/packages/tgui-say/handlers/keyDown.tsx
@@ -1,4 +1,4 @@
-import { KEY_BACKSPACE, KEY_DELETE, KEY_DOWN, KEY_TAB, KEY_UP } from 'common/keycodes';
+import { KEY_BACKSPACE, KEY_DELETE, KEY_DOWN, KEY_UP } from 'common/keycodes';
 import { isAlphanumeric, getHistoryLength } from '../helpers';
 import { Modal } from '../types';
 

--- a/tgui/packages/tgui-say/handlers/keyDown.tsx
+++ b/tgui/packages/tgui-say/handlers/keyDown.tsx
@@ -26,11 +26,6 @@ export const handleKeyDown = function (
     }
     return;
   }
-  if (event.keyCode === KEY_TAB) {
-    event.preventDefault();
-    this.events.onIncrementChannel();
-    return;
-  }
   if (event.keyCode === KEY_DELETE || event.keyCode === KEY_BACKSPACE) {
     this.events.onBackspaceDelete();
     return;


### PR DESCRIPTION
## About The Pull Request

## How Does This Help ***Gameplay***?
Tab hotkey was a crime, I have un-crimed the tab hotkey.

## How Does This Help ***Roleplay***?
Having what you say go to the wrong place is bad.

## Proof of Testing
It's pretty much not possible to do this without a video with an on-screen keyboard and I have 1 megabit upload speed so you'll just have to trust me.

## Changelog

:cl:
del: tab no longer changes tgui say channels
/:cl:
