### PR TITLE
Makes Proper borg ID display on the ORM

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -248,6 +248,13 @@
 				"name" = card.registered_account.account_holder,
 				"cash" = card.registered_account.account_balance,
 			)
+
+		else if(issilicon(user))
+			var/mob/living/silicon/silicon_player = user
+			data["user"] = list(
+				"name" = silicon_player.name,
+				"cash" = "No valid account",
+			)
 	return data
 
 /obj/machinery/mineral/ore_redemption/ui_static_data(mob/user)

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.js
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.js
@@ -32,20 +32,17 @@ export const OreRedemptionMachine = (props, context) => {
                     />
                   </Stack.Item>
                   <Stack.Item>
-                    {(!user && 'No user Detected') || (
-                      <LabeledList>
-                        <LabeledList.Item label="Name">
-                          {user.name || 'No name detected'}
-                        </LabeledList.Item>
-                        <LabeledList.Item label="Balance">
-                          {user.cash + ' cr' || 'No balance detected'}
-                        </LabeledList.Item>
-                      </LabeledList>
-                    )}
+                    <LabeledList>
+                      <LabeledList.Item label="Name">
+                        {user?.name || 'No Name Detected'}
+                      </LabeledList.Item>
+                      <LabeledList.Item label="Balance">
+                        {user?.cash || 'No Balance Detected'}
+                      </LabeledList.Item>
+                    </LabeledList>
                   </Stack.Item>
                   <Stack.Item>
                     <Button
-                      mt={0.5}
                       textAlign="center"
                       color={compact ? 'red' : 'green'}
                       content="Compact"


### PR DESCRIPTION
## About The Pull Request
https://github.com/tgstation/tgstation/pull/73808 Makes an ID display on the ORM for borgs. Right now it defaults to no ID detected.
## How Does This Help ***Gameplay***?
Borgs will have their ID shown on the ORM when they interact with it.
## How Does This Help ***Roleplay***?
Minimal impact on roleplay. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

### Current situation for borgs using the ORM
![](https://i.gyazo.com/843f964387eeebc73c1e15f97e4ced8d.png)
### Borgs using the ORM after this PR.
![](https://i.gyazo.com/dc5b437e5412e07d50f028e3302a5f11.png)

</details>

## Changelog
:cl:
qol: Borg IDs are shown on the ORM now when interacted with.
/:cl: