### PR TITLE
[PORT] Baylights

### DIFF
--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -33,3 +33,21 @@
 	dir = WEST; \
 	pixel_x = -offset; \
 }
+
+/// When you need to prescribe very specific offsets, use this over MAPPING_DIRECTIONAL_HELPERS
+#define MAPPING_DIRECTIONAL_HELPERS_ROBUST(path, n_offset, s_offset, e_offset, w_offset) ##path/directional/north {\
+	dir = NORTH; \
+	pixel_y = n_offset; \
+} \
+##path/directional/south {\
+	dir = SOUTH; \
+	pixel_y = s_offset; \
+} \
+##path/directional/east {\
+	dir = EAST; \
+	pixel_x = e_offset; \
+} \
+##path/directional/west {\
+	dir = WEST; \
+	pixel_x = w_offset; \
+}

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -122,6 +122,9 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/cold/no_nightlight, 21, 
 // ---- Red tubes
 MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/red, 21, 0, 10, -10)
 
+// ---- Red dim tubes
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/red/dim, 21, 0, 10, -10)
+
 // ---- Blacklight tubes
 MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/blacklight, 21, 0, 10, -10)
 

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -147,6 +147,9 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/broken, 21, 0, 10,
 // ---- Red bulbs
 MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/red, 21, 0, 10, -10)
 
+// ---- Red dim bulbs
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/red/dim, 21, 0, 10, -10)
+
 // ---- Blacklight bulbs
 MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/blacklight, 21, 0, 10, -10)
 

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -86,64 +86,66 @@
 	nightshift_allowed = FALSE
 	brightness = 4
 
+/obj/machinery/light/small/maintenance
+	bulb_colour = "#e0a142"
+	nightshift_allowed = FALSE
+	bulb_power = 0.8
+
 // -------- Directional presets
 // The directions are backwards on the lights we have now
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light, 21, 0, 10, -10)
 
 // ---- Broken tube
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/broken, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/broken, 21, 0, 10, -10)
 
 // ---- Tube construct
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/light_construct, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/structure/light_construct, 21, 0, 10, -10)
 
 // ---- Tube frames
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/built, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/built, 21, 0, 10, -10)
 
 // ---- No nightlight tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/no_nightlight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/no_nightlight, 21, 0, 10, -10)
 
 // ---- Warm light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/warm, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/warm, 21, 0, 10, -10)
 
 // ---- No nightlight warm light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/warm/no_nightlight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/warm/no_nightlight, 21, 0, 10, -10)
 
 // ---- Cold light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/cold, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/cold, 21, 0, 10, -10)
 
 // ---- No nightlight cold light tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/cold/no_nightlight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/cold/no_nightlight, 21, 0, 10, -10)
 
 // ---- Red tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/red, 0)
-
-// ---- Red dim tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/red/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/red, 21, 0, 10, -10)
 
 // ---- Blacklight tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/blacklight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/blacklight, 21, 0, 10, -10)
 
 // ---- Dim tubes
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/dim, 21, 0, 10, -10)
 
 
 // -------- Bulb lights
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small, 21, 0, 10, -10)
 
 // ---- Bulb construct
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/light_construct/small, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/structure/light_construct/small, 21, 0, 10, -10)
 
 // ---- Bulb frames
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/built, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/built, 21, 0, 10, -10)
 
 // ---- Broken bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/broken, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/broken, 21, 0, 10, -10)
 
 // ---- Red bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red, 0)
-
-// ---- Red dim bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red/dim, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/red, 21, 0, 10, -10)
 
 // ---- Blacklight bulbs
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/blacklight, 0)
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/blacklight, 21, 0, 10, -10)
+
+// ---- Maintenance bulbs
+MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light/small/maintenance, 21, 0, 10, -10)


### PR DESCRIPTION
## About The Pull Request

Shamelessly steals part of https://github.com/DaedalusDock/daedalusdock/pull/89

Makes our lights actually hang on the wall on all sides, rather than be at the base of the wall randomly.

Known issues: Fucks TG map light placements in many places. Not our problem, though.

## How Does This Help ***Gameplay***?

Better bulb placement.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/223590293-bdeb3a99-f12a-4438-a61c-b21d2ec820f4.png)

</details>

## Changelog

:cl:
add: Added a new maintenance light subtype. Dim and extremely warm, being basically orange.
qol: Made lights actually hang off of walls.
/:cl:
