### PR TITLE
DNR frees jobslots

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -415,7 +415,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		current_mob.log_message("had their player ([key_name(src)]) do-not-resuscitate / DNR", LOG_GAME, color = COLOR_GREEN, log_globally = FALSE)
 	log_message("has opted to do-not-resuscitate / DNR from their body ([current_mob])", LOG_GAME, color = COLOR_GREEN)
 	var/datum/job/job_to_free = SSjob.GetJob(current_mob.mind.assigned_role.title)
-	job_to_free.current_positions--
+	job_to_free?.current_positions--
 	// Disassociates observer mind from the body mind
 	mind = null
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -414,7 +414,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		current_mob.med_hud_set_status()
 		current_mob.log_message("had their player ([key_name(src)]) do-not-resuscitate / DNR", LOG_GAME, color = COLOR_GREEN, log_globally = FALSE)
 	log_message("has opted to do-not-resuscitate / DNR from their body ([current_mob])", LOG_GAME, color = COLOR_GREEN)
-
+	var/datum/job/job_to_free = SSjob.GetJob(current_mob.mind.assigned_role.title)
+	job_to_free.current_positions--
 	// Disassociates observer mind from the body mind
 	mind = null
 


### PR DESCRIPTION
## About The Pull Request
Simple PR that makes DNR verb free job slots.

## How Does This Help ***Gameplay***?

Let's recover job slots.

## How Does This Help ***Roleplay***?
Captain's funeral means a new captain comes in from headquarters. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->
this worked on the rodent server
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
code: DNR now frees up occupied job slots
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
