### PR TITLE
[PORT] Corrects Automatic Shuttle Boundary Generation

### DIFF
--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -14,10 +14,7 @@
 "c" = (
 /obj/docking_port/mobile/arrivals{
 	dir = 2;
-	dwidth = 4;
-	height = 17;
-	name = "delta arrivals shuttle";
-	width = 9
+	name = "delta arrivals shuttle"
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/arrival)

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -65,7 +65,6 @@
 	},
 /obj/docking_port/mobile/arrivals{
 	dir = 2;
-	height = 13;
 	name = "donut arrivals shuttle"
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -88,9 +88,7 @@
 	dir = 4
 	},
 /obj/docking_port/mobile/arrivals{
-	height = 13;
-	name = "pubby arrivals shuttle";
-	width = 6
+	name = "pubby arrivals shuttle"
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)

--- a/_maps/shuttles/cargo_birdboat.dmm
+++ b/_maps/shuttles/cargo_birdboat.dmm
@@ -100,10 +100,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Supply Shuttle Airlock"
 	},
-/obj/docking_port/mobile/supply{
-	dwidth = 3;
-	width = 10
-	},
+/obj/docking_port/mobile/supply,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/shuttle/supply)

--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -87,8 +87,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/mobile/supply{
-	dir = 4;
-	dwidth = 4
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -116,11 +116,10 @@
 	name = "Supply Shuttle Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/docking_port/mobile/supply{
-	dir = 4;
-	dwidth = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/docking_port/mobile/supply{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "n" = (

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -27,10 +27,7 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 2;
-	dwidth = 10;
-	height = 13;
-	name = "Asteroid emergency shuttle";
-	width = 28
+	name = "Asteroid emergency shuttle"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -184,11 +184,8 @@
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile/emergency{
 	dir = 8;
-	dwidth = 6;
-	height = 18;
 	name = "Birdboat emergency escape shuttle";
-	port_direction = 4;
-	width = 14
+	port_direction = 4
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_casino.dmm
+++ b/_maps/shuttles/emergency_casino.dmm
@@ -1014,10 +1014,7 @@
 "DO" = (
 /obj/docking_port/mobile/emergency{
 	dir = 2;
-	dwidth = 5;
-	height = 19;
-	name = "Casino emergency shuttle";
-	width = 35
+	name = "Casino emergency shuttle"
 	},
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -397,10 +397,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	dwidth = 15;
-	height = 20;
-	name = "Cere emergency shuttle";
-	width = 42
+	name = "Cere emergency shuttle"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -45,11 +45,9 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency/shuttle_build{
-	height = 15;
 	name = "Shuttle Under Construction";
 	port_direction = 4;
-	preferred_direction = 2;
-	width = 26
+	preferred_direction = 2
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -57,10 +57,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	dwidth = 3;
-	height = 5;
-	name = "Secure Transport Vessel 5";
-	width = 14
+	name = "Secure Transport Vessel 5"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -640,9 +640,7 @@
 	dir = 4
 	},
 /obj/docking_port/mobile/emergency{
-	height = 22;
-	name = "The NTSS Independence";
-	width = 44
+	name = "The NTSS Independence"
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -451,12 +451,9 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	dwidth = 11;
-	height = 18;
 	name = "Delta emergency shuttle";
 	port_direction = 4;
-	preferred_direction = 2;
-	width = 30
+	preferred_direction = 2
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -241,8 +241,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	name = "Donut emergency shuttle";
-	width = 34
+	name = "Donut emergency shuttle"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -36,8 +36,7 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 2;
-	name = "NES Port";
-	width = 19
+	name = "NES Port"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -4,10 +4,7 @@
 /area/shuttle/escape)
 "c" = (
 /obj/docking_port/mobile/emergency{
-	dwidth = 1;
-	height = 10;
-	name = "Oh Hi Daniel";
-	width = 12
+	name = "Oh Hi Daniel"
 	},
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/wood,

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -23,10 +23,7 @@
 "ae" = (
 /obj/docking_port/mobile/emergency{
 	dir = 2;
-	dwidth = 5;
-	height = 14;
-	name = "Luxurious Emergency Shuttle";
-	width = 25
+	name = "Luxurious Emergency Shuttle"
 	},
 /obj/machinery/scanner_gate/luxury_shuttle{
 	layer = 2.6

--- a/_maps/shuttles/emergency_medisim.dmm
+++ b/_maps/shuttles/emergency_medisim.dmm
@@ -1047,10 +1047,7 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 1;
-	dwidth = 6;
-	height = 26;
-	name = "Medisim emergency shuttle";
-	width = 25
+	name = "Medisim emergency shuttle"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -25,10 +25,7 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 2;
-	dwidth = 5;
-	height = 14;
-	name = "Meta emergency shuttle";
-	width = 25
+	name = "Meta emergency shuttle"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_meteor.dmm
+++ b/_maps/shuttles/emergency_meteor.dmm
@@ -65,11 +65,8 @@
 /area/shuttle/escape/meteor)
 "L" = (
 /obj/docking_port/mobile/emergency{
-	dwidth = 20;
-	height = 40;
 	movement_force = list("KNOCKDOWN"=3,"THROW"=6);
-	name = "\proper a meteor with engines strapped to it";
-	width = 40
+	name = "\proper a meteor with engines strapped to it"
 	},
 /turf/open/misc/asteroid,
 /area/shuttle/escape/meteor)

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -137,10 +137,7 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 8;
-	dwidth = 8;
-	height = 9;
-	name = "Mini emergency shuttle";
-	width = 21
+	name = "Mini emergency shuttle"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -2630,12 +2630,9 @@
 /area/shuttle/escape)
 "JZ" = (
 /obj/docking_port/mobile/emergency{
-	dwidth = 40;
-	height = 43;
 	movement_force = list("KNOCKDOWN"=3,"THROW"=6);
 	name = "\proper a monastery with engines strapped to it";
-	port_direction = 1;
-	width = 80
+	port_direction = 1
 	},
 /turf/closed/mineral,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -47,9 +47,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	dwidth = 5;
-	name = "Omega emergency shuttle";
-	width = 19
+	name = "Omega emergency shuttle"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -668,11 +668,8 @@
 	},
 /obj/docking_port/mobile/emergency{
 	dir = 8;
-	dwidth = 27;
-	height = 8;
 	name = "PubbyStation emergency shuttle";
-	port_direction = 4;
-	width = 46
+	port_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -2055,10 +2055,7 @@
 	name = "Emegency Shuttle External Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	dwidth = 14;
-	height = 21;
-	name = "CentCom Raven Cruiser";
-	width = 32
+	name = "CentCom Raven Cruiser"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -257,7 +257,6 @@
 /area/shuttle/escape)
 "aW" = (
 /obj/docking_port/mobile/emergency{
-	height = 15;
 	name = "Mother Russia Bleeds"
 	},
 /obj/machinery/door/airlock/security/glass{

--- a/_maps/shuttles/emergency_tram.dmm
+++ b/_maps/shuttles/emergency_tram.dmm
@@ -228,9 +228,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	height = 9;
-	name = "Tram emergency shuttle";
-	width = 32
+	name = "Tram emergency shuttle"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -289,9 +289,7 @@
 	name = "Transport Ship Zeta"
 	},
 /obj/docking_port/mobile/emergency{
-	height = 21;
-	name = "Zeta emergency shuttle";
-	width = 21
+	name = "Zeta emergency shuttle"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -61,10 +61,7 @@
 	name = "Shuttle Airlock"
 	},
 /obj/docking_port/mobile/pod{
-	dwidth = 2;
-	height = 6;
-	port_direction = 2;
-	width = 5
+	port_direction = 2
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)

--- a/_maps/shuttles/ferry_base.dmm
+++ b/_maps/shuttles/ferry_base.dmm
@@ -45,12 +45,9 @@
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 12;
 	shuttle_id = "ferry";
 	name = "ferry shuttle";
-	port_direction = 2;
-	width = 5
+	port_direction = 2
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -64,12 +64,9 @@
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 13;
 	shuttle_id = "ferry";
 	name = "ferry shuttle";
-	preferred_direction = 4;
-	width = 5
+	preferred_direction = 4
 	},
 /turf/open/floor/pod/light,
 /area/shuttle/transport)

--- a/_maps/shuttles/ferry_kilo.dmm
+++ b/_maps/shuttles/ferry_kilo.dmm
@@ -150,12 +150,9 @@
 /obj/structure/fans/tiny,
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 11;
 	shuttle_id = "ferry";
 	name = "ferry shuttle";
-	preferred_direction = 4;
-	width = 5
+	preferred_direction = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -150,12 +150,9 @@
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 8;
-	height = 27;
 	shuttle_id = "ferry";
 	name = "The Lighthouse";
-	port_direction = 2;
-	width = 16
+	port_direction = 2
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)

--- a/_maps/shuttles/ferry_meat.dmm
+++ b/_maps/shuttles/ferry_meat.dmm
@@ -102,12 +102,9 @@
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 12;
 	shuttle_id = "ferry";
 	name = "ferry shuttle";
-	port_direction = 2;
-	width = 5
+	port_direction = 2
 	},
 /turf/open/floor/iron/freezer,
 /area/shuttle/transport)

--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -198,14 +198,10 @@
 	width = 17
 	},
 /obj/docking_port/mobile{
-	dheight = 3;
-	dwidth = 3;
-	height = 13;
 	shuttle_id = "huntership";
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "hunter shuttle";
-	rechargeTime = 1800;
-	width = 15
+	rechargeTime = 1800
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -495,14 +495,10 @@
 /area/shuttle/hunter/russian)
 "JS" = (
 /obj/docking_port/mobile{
-	dheight = 3;
-	dwidth = 3;
-	height = 13;
 	shuttle_id = "huntership";
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "hunter shuttle";
-	rechargeTime = 1800;
-	width = 15
+	rechargeTime = 1800
 	},
 /obj/docking_port/stationary{
 	dwidth = 11;

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -25,12 +25,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 4;
-	dwidth = 3;
-	height = 12;
 	shuttle_id = "huntership";
 	name = "hunter shuttle";
-	rechargeTime = 1800;
-	width = 7
+	rechargeTime = 1800
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Interpolship"

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -95,11 +95,8 @@
 "q" = (
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 5;
 	shuttle_id = "laborcamp";
 	name = "labor camp shuttle";
-	width = 9;
 	port_direction = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -228,12 +228,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 5;
 	shuttle_id = "laborcamp";
 	name = "labor camp shuttle";
-	port_direction = 4;
-	width = 9
+	port_direction = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/shuttles/labour_generic.dmm
+++ b/_maps/shuttles/labour_generic.dmm
@@ -88,11 +88,8 @@
 "q" = (
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 5;
 	shuttle_id = "laborcamp";
 	name = "labor camp shuttle";
-	width = 9;
 	port_direction = 4
 	},
 /obj/machinery/door/airlock/titanium{

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -217,12 +217,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 2;
-	height = 5;
 	shuttle_id = "laborcamp";
 	name = "labor camp shuttle";
-	port_direction = 4;
-	width = 9
+	port_direction = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4

--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -33,12 +33,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 3;
-	height = 5;
 	shuttle_id = "mining";
 	name = "mining shuttle";
-	port_direction = 4;
-	width = 7
+	port_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/mining)

--- a/_maps/shuttles/mining_common_kilo.dmm
+++ b/_maps/shuttles/mining_common_kilo.dmm
@@ -82,12 +82,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 3;
-	height = 5;
 	shuttle_id = "mining_common";
 	name = "lavaland shuttle";
-	port_direction = 4;
-	width = 7
+	port_direction = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4

--- a/_maps/shuttles/mining_common_meta.dmm
+++ b/_maps/shuttles/mining_common_meta.dmm
@@ -33,12 +33,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 3;
-	height = 5;
 	shuttle_id = "mining_common";
 	name = "lavaland shuttle";
-	port_direction = 4;
-	width = 7
+	port_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/mining)

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -69,12 +69,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 4;
-	dwidth = 3;
-	height = 5;
 	shuttle_id = "mining";
 	name = "mining shuttle";
-	port_direction = 8;
-	width = 7
+	port_direction = 8
 	},
 /turf/open/floor/iron/white,
 /area/shuttle/mining)

--- a/_maps/shuttles/mining_freight.dmm
+++ b/_maps/shuttles/mining_freight.dmm
@@ -80,12 +80,9 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 3;
-	height = 5;
 	shuttle_id = "mining_common";
 	name = "lavaland shuttle";
-	port_direction = 4;
-	width = 7
+	port_direction = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -319,12 +319,9 @@
 	dir = 1
 	},
 /obj/docking_port/mobile{
-	dwidth = 3;
-	height = 10;
 	shuttle_id = "mining";
 	name = "mining shuttle";
-	port_direction = 2;
-	width = 7
+	port_direction = 2
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -443,12 +443,9 @@
 	dir = 1
 	},
 /obj/docking_port/mobile{
-	dwidth = 3;
-	height = 10;
 	shuttle_id = "mining";
 	name = "mining shuttle";
-	port_direction = 2;
-	width = 7
+	port_direction = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -1072,13 +1072,10 @@
 	dir = 1
 	},
 /obj/docking_port/mobile/pirate{
-	dwidth = 11;
-	height = 16;
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Pirate Ship";
-	port_direction = 2;
-	width = 17
+	port_direction = 2
 	},
 /obj/docking_port/stationary{
 	dwidth = 11;

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -771,16 +771,12 @@
 	width = 17
 	},
 /obj/docking_port/mobile/pirate{
-	dheight = 7;
 	dir = 8;
-	dwidth = 18;
-	height = 6;
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Pirate Ship";
 	port_direction = 4;
-	preferred_direction = 8;
-	width = 13
+	preferred_direction = 8
 	},
 /turf/open/floor/wood/airless,
 /area/shuttle/pirate/flying_dutchman)

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -522,13 +522,10 @@
 	},
 /obj/docking_port/mobile/pirate{
 	dir = 4;
-	dwidth = 13;
-	height = 3;
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Silverscale Cruiser";
-	preferred_direction = 4;
-	width = 26
+	preferred_direction = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -927,14 +927,11 @@
 /obj/docking_port/mobile{
 	callTime = 250;
 	dir = 2;
-	dwidth = 5;
-	height = 11;
 	shuttle_id = "caravantrade1";
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Small Freighter";
 	port_direction = 8;
-	preferred_direction = 4;
-	width = 21
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/caravan/freighter1)

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -667,14 +667,11 @@
 /obj/docking_port/mobile{
 	callTime = 150;
 	dir = 2;
-	dwidth = 14;
-	height = 13;
 	shuttle_id = "caravanpirate";
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Pirate Cutter";
 	port_direction = 8;
-	preferred_direction = 4;
-	width = 22
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/caravan/pirate)

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -72,13 +72,10 @@
 	},
 /obj/docking_port/mobile{
 	dir = 2;
-	dwidth = 6;
-	height = 7;
 	shuttle_id = "caravansyndicate3";
 	name = "Syndicate Drop Ship";
 	port_direction = 8;
-	preferred_direction = 4;
-	width = 15
+	preferred_direction = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -82,14 +82,11 @@
 /obj/docking_port/mobile{
 	callTime = 50;
 	dir = 4;
-	dwidth = 4;
-	height = 5;
 	shuttle_id = "caravansyndicate1";
 	ignitionTime = 25;
 	name = "Syndicate Fighter";
 	port_direction = 2;
-	preferred_direction = 4;
-	width = 9
+	preferred_direction = 4
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,

--- a/_maps/shuttles/snowdin_excavation.dmm
+++ b/_maps/shuttles/snowdin_excavation.dmm
@@ -5,10 +5,8 @@
 	},
 /obj/docking_port/mobile/elevator{
 	dir = 4;
-	height = 6;
 	shuttle_id = "snowdin_excavation";
-	name = "excavation elevator";
-	width = 6
+	name = "excavation elevator"
 	},
 /turf/open/floor/plating,
 /area/shuttle/snowdin/elevator1)

--- a/_maps/shuttles/snowdin_mining.dmm
+++ b/_maps/shuttles/snowdin_mining.dmm
@@ -5,11 +5,8 @@
 	},
 /obj/docking_port/mobile/elevator{
 	dir = 4;
-	dwidth = 2;
-	height = 5;
 	shuttle_id = "snowdin_mining";
-	name = "mining elevator";
-	width = 5
+	name = "mining elevator"
 	},
 /turf/open/floor/plating,
 /area/shuttle/snowdin/elevator2)

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -18,15 +18,12 @@
 /obj/docking_port/mobile{
 	callTime = 250;
 	dir = 2;
-	dwidth = 11;
-	height = 17;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Hospital Ship";
 	port_direction = 8;
-	preferred_direction = 4;
-	width = 34
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -12,13 +12,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/docking_port/mobile{
 	dir = 2;
-	dwidth = 8;
-	height = 16;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	name = "NT Recovery White-Ship";
-	port_direction = 8;
-	width = 16
+	port_direction = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -20,15 +20,12 @@
 /obj/docking_port/mobile{
 	callTime = 250;
 	dir = 2;
-	dwidth = 11;
-	height = 17;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "NT Frigate";
 	port_direction = 8;
-	preferred_direction = 4;
-	width = 27
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -13,13 +13,10 @@
 /obj/machinery/door/airlock/external/glass/ruin,
 /obj/docking_port/mobile{
 	dir = 2;
-	dwidth = 8;
-	height = 17;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	name = "White Ship";
-	port_direction = 2;
-	width = 9
+	port_direction = 2
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -246,16 +246,12 @@
 	callTime = 250;
 	can_move_docking_ports = 1;
 	dir = 2;
-	dwidth = 7;
-	height = 17;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Mining Shuttle";
 	port_direction = 4;
-	preferred_direction = 8;
-	width = 13;
-	dheight = 7
+	preferred_direction = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -36,15 +36,12 @@
 	callTime = 250;
 	can_move_docking_ports = 1;
 	dir = 2;
-	dwidth = 11;
-	height = 17;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Salvage Ship";
 	port_direction = 8;
-	preferred_direction = 4;
-	width = 33
+	preferred_direction = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned/crew)

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -85,13 +85,10 @@
 	},
 /obj/docking_port/mobile{
 	dir = 8;
-	dwidth = 4;
-	height = 9;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	name = "White Ship";
-	port_direction = 4;
-	width = 9
+	port_direction = 4
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned)

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -576,13 +576,10 @@
 "bN" = (
 /obj/docking_port/mobile{
 	dir = 2;
-	dwidth = 6;
-	height = 27;
 	shuttle_id = "whiteship";
 	launch_status = 0;
 	name = "White Ship";
-	port_direction = 2;
-	width = 13
+	port_direction = 2
 	},
 /obj/effect/turf_decal/stripes/white/box,
 /obj/machinery/door/airlock/external/ruin,

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -67,31 +67,33 @@
 		place.baseturfs = baseturfs_string_list(sanity, place)
 
 		for(var/obj/docking_port/mobile/port in place)
+			if(!isnull(port_x_offset))
+				switch(port.dir) // Yeah this looks a little ugly but mappers had to do this in their head before
+					if(NORTH)
+						port.width = width
+						port.height = height
+						port.dwidth = port_x_offset - 1
+						port.dheight = port_y_offset - 1
+					if(EAST)
+						port.width = height
+						port.height = width
+						port.dwidth = height - port_y_offset
+						port.dheight = port_x_offset - 1
+					if(SOUTH)
+						port.width = width
+						port.height = height
+						port.dwidth = width - port_x_offset
+						port.dheight = height - port_y_offset
+					if(WEST)
+						port.width = height
+						port.height = width
+						port.dwidth = port_y_offset - 1
+						port.dheight = width - port_x_offset
+			// initTemplateBounds explicitly ignores the shuttle's docking port, to ensure that it calculates the bounds of the shuttle correctly
+			// so we need to manually initialize it here
+			SSatoms.InitializeAtoms(list(port))
 			if(register)
 				port.register()
-			if(isnull(port_x_offset))
-				continue
-			switch(port.dir) // Yeah this looks a little ugly but mappers had to do this in their head before
-				if(NORTH)
-					port.width = width
-					port.height = height
-					port.dwidth = port_x_offset - 1
-					port.dheight = port_y_offset - 1
-				if(EAST)
-					port.width = height
-					port.height = width
-					port.dwidth = height - port_y_offset
-					port.dheight = port_x_offset - 1
-				if(SOUTH)
-					port.width = width
-					port.height = height
-					port.dwidth = width - port_x_offset
-					port.dheight = height - port_y_offset
-				if(WEST)
-					port.width = height
-					port.height = width
-					port.dwidth = port_y_offset - 1
-					port.dheight = width - port_x_offset
 
 //Whatever special stuff you want
 /datum/map_template/shuttle/post_load(obj/docking_port/mobile/M)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -75,6 +75,8 @@
 			continue
 
 		for(var/movable_in_turf in current_turf)
+			if(istype(movable_in_turf, /obj/docking_port/mobile))
+				continue // mobile docking ports need to be initialized after their template has finished loading, to ensure that their bounds are setup
 			movables += movable_in_turf
 			if(istype(movable_in_turf, /obj/structure/cable))
 				cables += movable_in_turf

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -310,11 +310,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 /obj/docking_port/mobile/auxiliary_base
 	name = "auxiliary base"
 	shuttle_id = "colony_drop"
-	//Reminder to map-makers to set these values equal to the size of your base.
-	dheight = 4
-	dwidth = 4
-	width = 9
-	height = 9
 
 /obj/docking_port/mobile/auxiliary_base/takeoff(list/old_turfs, list/new_turfs, list/moved_atoms, rotation, movement_direction, old_dock, area/underlying_old_area)
 	for(var/i in new_turfs)

--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -2,9 +2,6 @@
 	name = "arrivals shuttle"
 	shuttle_id = "arrival"
 
-	dwidth = 3
-	width = 7
-	height = 15
 	dir = WEST
 	port_direction = SOUTH
 

--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -1,9 +1,6 @@
 /obj/docking_port/mobile/assault_pod
 	name = "assault pod"
 	shuttle_id = "steel_rain"
-	dwidth = 3
-	width = 7
-	height = 7
 
 /obj/docking_port/mobile/assault_pod/request(obj/docking_port/stationary/S)
 	if(!(z in SSmapping.levels_by_trait(ZTRAIT_STATION))) //No launching pods that have already launched

--- a/code/modules/shuttle/battlecruiser_starfury.dm
+++ b/code/modules/shuttle/battlecruiser_starfury.dm
@@ -47,9 +47,6 @@
 	hidden = TRUE
 	dir = NORTH
 	port_direction = SOUTH
-	width = 5
-	height = 7
-	dwidth = 2
 
 /obj/docking_port/mobile/syndicate_fighter/fighter_one
 	name = "syndicate fighter one"
@@ -71,9 +68,6 @@
 	dir = NORTH
 	port_direction = SOUTH
 	preferred_direction = WEST
-	width = 14
-	dwidth = 6
-	height = 7
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/fighter
 	name = "syndicate fighter navigation computer"

--- a/code/modules/shuttle/elevator.dm
+++ b/code/modules/shuttle/elevator.dm
@@ -1,9 +1,6 @@
 /obj/docking_port/mobile/elevator
 	name = "elevator"
 	shuttle_id = "elevator"
-	dwidth = 3
-	width = 7
-	height = 7
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 
 /obj/docking_port/mobile/elevator/request(obj/docking_port/stationary/S) //No transit, no ignition, just a simple up/down platform

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -303,10 +303,6 @@
 /obj/docking_port/mobile/emergency
 	name = "emergency shuttle"
 	shuttle_id = "emergency"
-
-	dwidth = 9
-	width = 22
-	height = 11
 	dir = EAST
 	port_direction = WEST
 	var/sound_played = 0 //If the launch sound has been sent to all players on the shuttle itself
@@ -571,9 +567,6 @@
 /obj/docking_port/mobile/pod
 	name = "escape pod"
 	shuttle_id = "pod"
-	dwidth = 1
-	width = 3
-	height = 4
 	launch_status = UNLAUNCHED
 
 /obj/docking_port/mobile/pod/request(obj/docking_port/stationary/S)
@@ -633,9 +626,6 @@
 /obj/docking_port/stationary/random
 	name = "escape pod"
 	shuttle_id = "pod"
-	dwidth = 1
-	width = 3
-	height = 4
 	hidden = TRUE
 	var/target_area = /area/lavaland/surface/outdoors
 	var/edge_distance = 16
@@ -745,9 +735,6 @@
 /obj/docking_port/mobile/emergency/backup
 	name = "backup shuttle"
 	shuttle_id = "backup"
-	dwidth = 2
-	width = 8
-	height = 8
 	dir = EAST
 
 /obj/docking_port/mobile/emergency/backup/Initialize(mapload)

--- a/code/modules/shuttle/infiltrator.dm
+++ b/code/modules/shuttle/infiltrator.dm
@@ -4,10 +4,6 @@
 	shuttle_id = "syndicate"
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 	hidden = TRUE
-	dheight = 1
-	dwidth = 12
-	height = 17
-	width = 23
 	dir = 8
 	port_direction = 4
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -47,11 +47,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	dir = WEST
 	port_direction = EAST
-	width = 12
-	dwidth = 5
-	height = 7
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
-
 
 	//Export categories for this run, this is set by console sending the shuttle.
 	var/export_categories = EXPORT_CARGO

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -289,6 +289,11 @@ if grep -i '/obj/effect/mapping_helpers/custom_icon' _maps/**/*.dmm; then
     echo -e "${RED}ERROR: Custom icon helper found. Please include DMI files as standard assets instead for repository maps.${NC}"
     st=1
 fi;
+if grep -P '^/obj/docking_port/mobile.*\{\n[^}]*(width|height|dwidth|dheight)[^}]*\}' _maps/**/*.dmm; then
+	echo
+	echo -e "${RED}ERROR: Custom mobile docking_port sizes detected. This is done automatically and should not be varedits.${NC}"
+	st=1
+fi;
 for json in _maps/*.json
 do
     map_path=$(jq -r '.map_path' $json)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/71220

When you load a map template, it does many things before considering itself finalized.
One of these steps is to iterate over all the loaded items and initialize/process them.
Unfortunately because a shuttle setups the bounds after initTemplateBounds is called, the mobile docking port ends up being initialized before the bounds are actually setup correctly. The solution to this is to explicitly ignore the mobile docking port, and have it initialize immediately after calculating the bounds

## How Does This Help ***Gameplay***?

<!-- Optional, remove the above header if unused. Describe why you made these changes from a mechanical perspective. Failure to include important reasoning, no matter how petty, may end in your PR being held under tighter scrutiny. -->

Makes mapping SIGNIFICANTLY easier for shuttles.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/223874017-91cceff4-e8b6-446e-8d1c-2e6d88d3baac.png)
![image](https://user-images.githubusercontent.com/106692773/223874058-62dc5271-dde3-45be-a146-d4484855c522.png)
![image](https://user-images.githubusercontent.com/106692773/223874778-c816aacf-4549-40fe-b867-181d7a6cbd79.png)

It compiles and shuttles don't disintegrate. I'll post caps tomorrow.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Mobile docking ports now actually autoset their sizes for the shuttle template they're on.
/:cl: