### PR TITLE
[PORT] Ports 3/4 Centcom walls from Pariah

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
@@ -4,7 +4,7 @@
 /area/icemoon/surface/outdoors/unexplored)
 "b" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/icemoon/surface/outdoors)
 "c" = (
 /turf/open/floor/mineral/diamond,

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_mailroom.dmm
@@ -14,7 +14,7 @@
 /area/ruin/powered/mailroom)
 "aG" = (
 /obj/structure/sign/warning/cold_temp,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "ba" = (
 /obj/structure/window/reinforced{
@@ -139,7 +139,7 @@
 /turf/closed/mineral/random/snow,
 /area/icemoon/underground/unexplored)
 "ms" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "mA" = (
 /obj/structure/fence/corner,
@@ -216,7 +216,7 @@
 /area/ruin/powered/mailroom)
 "vU" = (
 /obj/structure/sign/departments/cargo,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "vV" = (
 /obj/effect/decal/cleanable/oil,
@@ -259,7 +259,7 @@
 /area/ruin/powered/mailroom)
 "AX" = (
 /obj/structure/sign/warning/no_smoking/circle,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "BZ" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
@@ -272,7 +272,7 @@
 /area/ruin/powered/mailroom)
 "CW" = (
 /obj/structure/sign/poster/official/obey,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "DR" = (
 /obj/structure/fence/post{
@@ -299,7 +299,7 @@
 /area/ruin/powered/mailroom)
 "Gn" = (
 /obj/structure/sign/poster/ripped,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "HH" = (
 /turf/open/floor/iron/smooth_corner{
@@ -514,7 +514,7 @@
 /area/ruin/powered/mailroom)
 "Xa" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/powered/mailroom)
 "XO" = (
 /turf/open/floor/iron/smooth_corner{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -58,7 +58,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ak" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/ruin/unpowered/ash_walkers)
 "al" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -502,7 +502,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "bG" = (
-/turf/closed/indestructible/riveted/boss/see_through,
+/turf/closed/wall/indestructible/reinforced/boss/see_through,
 /area/ruin/unpowered/ash_walkers)
 "bH" = (
 /obj/structure/necropolis_gate,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
@@ -10,7 +10,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "d" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/lavaland/surface/outdoors)
 "e" = (
 /obj/machinery/wish_granter,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -185,7 +185,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "nT" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/ruin/powered/gluttony)
 "pj" = (
 /obj/structure/stone_tile/block/burnt{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hierophant.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hierophant.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted/hierophant,
+/turf/closed/indestructible/hierophant,
 /area/ruin/unpowered/hierophant)
 "b" = (
 /turf/open/indestructible/hierophant,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -141,7 +141,7 @@
 /turf/open/lava/smooth/weak,
 /area/ruin/powered/pride)
 "Y" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/ruin/powered/pride)
 "Z" = (
 /obj/structure/stone_tile/block{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/unpowered)
 "b" = (
 /turf/open/lava/smooth/lava_land_surface,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wizard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wizard.dmm
@@ -269,7 +269,7 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "D" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/lavaland/surface/outdoors)
 "E" = (
 /obj/structure/stone_tile/block{
@@ -286,7 +286,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "G" = (
-/turf/closed/indestructible/riveted/boss/see_through,
+/turf/closed/wall/indestructible/reinforced/boss/see_through,
 /area/lavaland/surface/outdoors)
 "H" = (
 /obj/structure/necropolis_gate,

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1017,7 +1017,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/secure_storage)
 "oP" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	color = "#FF8888"
 	},
 /area/ruin/space/ks13/ai/vault)

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -287,7 +287,7 @@
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
 "aZ" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "ba" = (
 /turf/closed/mineral/random,

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -46,7 +46,7 @@
 /turf/open/floor/plastic,
 /area/ruin/space/has_grav/hellfactory)
 "ah" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "ai" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -58,7 +58,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/layer4{
 	dir = 8
 	},
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/ruin/space/has_grav/hellfactoryoffice)
 "aj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{

--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -1230,7 +1230,7 @@
 /turf/closed/mineral/asteroid/porous,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Bo" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "BA" = (
 /obj/machinery/door/airlock/science{
@@ -1258,7 +1258,7 @@
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "BJ" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility/secretroom)
 "BL" = (
 /obj/structure/table/wood,
@@ -1368,7 +1368,7 @@
 /obj/structure/light_puzzle{
 	puzzle_id = "hilbert"
 	},
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Eu" = (
 /obj/item/kirbyplants/random,
@@ -1580,7 +1580,7 @@
 /turf/open/floor/grass/fairy,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Iy" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility/secretroom)
 "ID" = (
 /obj/structure/table/reinforced/rglass,
@@ -1850,7 +1850,7 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Ok" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "OA" = (
 /obj/machinery/door/airlock/titanium{
@@ -1976,7 +1976,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Rq" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/ruin/unpowered/no_grav)
 "Ru" = (
 /obj/effect/turf_decal/stripes/red/line{

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -694,11 +694,11 @@
 /turf/open/floor/iron/white,
 /area/awaymission/cabin)
 "cx" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/cabin/caves/mountain)
 "cy" = (
 /obj/structure/sign/poster/contraband/fun_police,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/cabin/caves/mountain)
 "cz" = (
 /obj/machinery/light/directional/north,
@@ -2368,7 +2368,7 @@
 /turf/open/floor/plating/snowed/snow_cabin,
 /area/awaymission/cabin/snowforest/sovietsurface)
 "ii" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "ij" = (
 /obj/structure/table/wood,
@@ -3448,11 +3448,11 @@
 /area/awaymission/cabin/snowforest/sovietsurface)
 "nn" = (
 /obj/structure/sign/warning/explosives,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "no" = (
 /obj/structure/sign/warning,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/awaymission/cabin/caves/sovietcave)
 "np" = (
 /turf/closed/indestructible/fakedoor{

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3,7 +3,7 @@
 /turf/open/space,
 /area/space)
 "ab" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/undergroundoutpost45/caves)
 "ad" = (
 /turf/closed/mineral/random/labormineral,

--- a/_maps/map_files/CTF/classic.dmm
+++ b/_maps/map_files/CTF/classic.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "av" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ctf)
 "aY" = (
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/map_files/CTF/cruiser.dmm
+++ b/_maps/map_files/CTF/cruiser.dmm
@@ -32,7 +32,7 @@
 /turf/open/floor/pod/light,
 /area/centcom/ctf)
 "ck" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/ctf)
 "cl" = (
 /obj/structure/window/reinforced{
@@ -42,7 +42,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/ctf)
 "cu" = (
 /obj/machinery/capture_the_flag/green,
@@ -152,7 +152,7 @@
 /turf/closed/indestructible/alien,
 /area/centcom/ctf)
 "fU" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/centcom/ctf)
 "gr" = (
 /obj/effect/turf_decal/siding/purple{
@@ -220,7 +220,7 @@
 	resistance_flags = 64
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/ctf)
 "lL" = (
 /obj/structure/table/reinforced/ctf,
@@ -237,7 +237,7 @@
 /obj/structure/sign/warning/radiation/rad_area{
 	resistance_flags = 64
 	},
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/centcom/ctf)
 "lY" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
@@ -547,7 +547,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 4
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/ctf)
 "FZ" = (
 /obj/effect/turf_decal/tile/red{

--- a/_maps/map_files/CTF/fourSide.dmm
+++ b/_maps/map_files/CTF/fourSide.dmm
@@ -68,7 +68,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/ctf)
 "cJ" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ctf)
 "df" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -198,7 +198,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/ctf)
 "lt" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/template_noop)
 "lF" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,

--- a/_maps/map_files/CTF/limbo.dmm
+++ b/_maps/map_files/CTF/limbo.dmm
@@ -1023,7 +1023,7 @@
 /turf/open/floor/carpet/orange,
 /area/centcom/ctf)
 "Xl" = (
-/turf/closed/indestructible/riveted/uranium,
+/turf/closed/wall/indestructible/uranium,
 /area/centcom/ctf)
 "Yl" = (
 /obj/effect/portal/permanent{

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3551,7 +3551,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "beZ" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/map_files/Mafia/mafia_ayylmao.dmm
+++ b/_maps/map_files/Mafia/mafia_ayylmao.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "b" = (
 /turf/closed/indestructible/alien,

--- a/_maps/map_files/Mafia/mafia_ball.dmm
+++ b/_maps/map_files/Mafia/mafia_ball.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "b" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/centcom/mafia)
 "c" = (
 /turf/closed/wall/rust,

--- a/_maps/map_files/Mafia/mafia_gothic.dmm
+++ b/_maps/map_files/Mafia/mafia_gothic.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "b" = (
 /turf/closed/wall/mineral/iron,

--- a/_maps/map_files/Mafia/mafia_lavaland.dmm
+++ b/_maps/map_files/Mafia/mafia_lavaland.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "c" = (
 /turf/closed/wall/rust,
@@ -341,7 +341,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/mafia)
 "Y" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 
 (1,1,1) = {"

--- a/_maps/map_files/Mafia/mafia_snow.dmm
+++ b/_maps/map_files/Mafia/mafia_snow.dmm
@@ -1,9 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "b" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/centcom/mafia)
 "d" = (
 /turf/open/floor/plating,

--- a/_maps/map_files/Mafia/mafia_spiderclan.dmm
+++ b/_maps/map_files/Mafia/mafia_spiderclan.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "b" = (
 /obj/structure/closet/cabinet{

--- a/_maps/map_files/Mafia/mafia_syndie.dmm
+++ b/_maps/map_files/Mafia/mafia_syndie.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/mafia)
 "b" = (
 /obj/structure/closet/syndicate{
@@ -120,7 +120,7 @@
 /turf/open/floor/plating,
 /area/centcom/mafia)
 "w" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/mafia)
 "x" = (
 /obj/effect/turf_decal/tile/red,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5478,7 +5478,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "bXO" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/lavaland/surface/outdoors)
 "ab" = (
 /obj/effect/decal/cleanable/dirt,
@@ -875,7 +875,7 @@
 /turf/open/floor/plating,
 /area/mine/maintenance/service)
 "fV" = (
-/turf/closed/indestructible/riveted/boss/see_through,
+/turf/closed/wall/indestructible/reinforced/boss/see_through,
 /area/lavaland/surface/outdoors)
 "fW" = (
 /obj/structure/necropolis_gate/locked,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -264,7 +264,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 4
 	},
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "aR" = (
 /obj/item/kirbyplants{
@@ -309,7 +309,7 @@
 /area/centcom/central_command_areas/briefing)
 "aW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -575,7 +575,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "bK" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_fridgerummage)
 "bL" = (
 /obj/structure/chair/stool/bar/directional/west,
@@ -719,7 +719,7 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/holding)
 "cg" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/evacuation)
 "ch" = (
 /obj/machinery/firealarm/directional/east,
@@ -2352,7 +2352,7 @@
 /turf/open/floor/wood/tile,
 /area/centcom/syndicate_mothership/control)
 "gO" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/briefing)
 "gQ" = (
 /obj/structure/rack,
@@ -2378,7 +2378,7 @@
 /area/centcom/central_command_areas/courtroom)
 "gS" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/ferry)
 "gT" = (
 /obj/item/kirbyplants{
@@ -2929,7 +2929,7 @@
 	},
 /area/awaymission/errorroom)
 "il" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/prison)
 "im" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2940,10 +2940,10 @@
 /area/centcom/central_command_areas/prison)
 "in" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/control)
 "io" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/control)
 "ip" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3076,7 +3076,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iF" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/supply)
 "iG" = (
 /turf/closed/indestructible/fakedoor{
@@ -3085,7 +3085,7 @@
 /area/centcom/central_command_areas/supply)
 "iH" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/prison)
 "iJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3115,7 +3115,7 @@
 /area/centcom/central_command_areas/prison)
 "iN" = (
 /obj/machinery/status_display/supply,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/supply)
 "iO" = (
 /obj/effect/turf_decal/delivery,
@@ -3719,7 +3719,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership)
 "kv" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "kw" = (
 /turf/open/floor/iron/showroomfloor,
@@ -3839,7 +3839,7 @@
 /area/centcom/abductor_ship)
 "kR" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/admin/storage)
 "kS" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4433,7 +4433,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "mD" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/ferry)
 "mE" = (
 /obj/structure/chair/comfy/brown{
@@ -4684,7 +4684,7 @@
 	},
 /area/centcom/abductor_ship)
 "ng" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "ni" = (
 /obj/machinery/light/directional/south,
@@ -4826,7 +4826,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "nH" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "nJ" = (
 /obj/machinery/firealarm/directional/south,
@@ -5376,7 +5376,7 @@
 /area/centcom/syndicate_mothership/control)
 "pc" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/courtroom)
 "pd" = (
 /obj/item/clipboard,
@@ -5808,7 +5808,7 @@
 /area/centcom/syndicate_mothership/expansion_fridgerummage)
 "qq" = (
 /obj/structure/sign/warning/no_smoking,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/admin)
 "qr" = (
 /obj/structure/closet/crate/bin,
@@ -5922,7 +5922,7 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "qE" = (
-/turf/closed/indestructible/riveted/uranium,
+/turf/closed/wall/indestructible/uranium,
 /area/centcom/wizard_station)
 "qF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5981,7 +5981,7 @@
 /area/centcom/syndicate_mothership/control)
 "qR" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/ferry)
 "qS" = (
 /obj/machinery/door/airlock/centcom{
@@ -6297,7 +6297,7 @@
 /area/centcom/wizard_station)
 "rY" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/armory)
 "rZ" = (
 /obj/machinery/shower/directional/west,
@@ -6654,7 +6654,7 @@
 /area/centcom/central_command_areas/holding)
 "td" = (
 /obj/structure/sign/departments/drop,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/ferry)
 "tg" = (
 /obj/structure/chair{
@@ -6946,7 +6946,7 @@
 /area/centcom/wizard_station)
 "tY" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "ub" = (
 /obj/machinery/door/firedoor,
@@ -6967,7 +6967,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "uf" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/tdome/administration)
 "ug" = (
 /obj/machinery/light/directional/east,
@@ -8160,7 +8160,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "xN" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -8741,7 +8741,7 @@
 /area/centcom/syndicate_mothership/control)
 "zw" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/tdome/observation)
 "zz" = (
 /obj/structure/table/reinforced,
@@ -9080,7 +9080,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "As" = (
 /obj/machinery/computer/communications{
@@ -9258,7 +9258,7 @@
 /area/centcom/syndicate_mothership/control)
 "AT" = (
 /obj/structure/sign/departments/medbay/alt,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/control)
 "AU" = (
 /obj/machinery/computer/operating{
@@ -10009,7 +10009,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "CN" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "CP" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -10117,11 +10117,11 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/syndicate_mothership/control)
 "Di" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/ai_multicam_room)
 "Dj" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/prison/cells)
 "Dk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10273,7 +10273,7 @@
 /area/centcom/wizard_station)
 "DF" = (
 /obj/structure/sign/warning/no_smoking,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/tdome/observation)
 "DG" = (
 /obj/structure/chair/office{
@@ -10379,7 +10379,7 @@
 /area/centcom/wizard_station)
 "DT" = (
 /obj/structure/sign/poster/contraband/cc64k_ad,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "DV" = (
 /obj/item/kirbyplants{
@@ -10775,7 +10775,7 @@
 /area/centcom/tdome/administration)
 "Fd" = (
 /obj/structure/sign/poster/contraband/free_key,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "Fe" = (
 /obj/structure/sink/directional/west,
@@ -10868,7 +10868,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "Fq" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/control)
 "Fr" = (
 /obj/machinery/light/cold/directional/north,
@@ -11367,7 +11367,7 @@
 /area/centcom/syndicate_mothership/control)
 "GI" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "GJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11380,7 +11380,7 @@
 /area/centcom/central_command_areas/evacuation)
 "GK" = (
 /obj/structure/cable,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "GL" = (
 /obj/structure/table/reinforced,
@@ -11587,7 +11587,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
 "Hv" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/courtroom)
 "Hy" = (
 /obj/machinery/recharge_station,
@@ -12160,7 +12160,7 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
 "Jb" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/prison/cells)
 "Jc" = (
 /obj/effect/landmark/thunderdome/one,
@@ -12901,7 +12901,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/central_command_areas/evacuation/ship)
 "LV" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/awaymission/errorroom)
 "LW" = (
 /turf/closed/mineral/ash_rock,
@@ -13250,7 +13250,7 @@
 /area/centcom/central_command_areas/holding)
 "MY" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/briefing)
 "MZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -13718,7 +13718,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "On" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/admin)
 "Op" = (
 /obj/structure/table/reinforced,
@@ -14254,7 +14254,7 @@
 /area/centcom/central_command_areas/armory)
 "PF" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/admin)
 "PH" = (
 /obj/machinery/firealarm/directional/south,
@@ -14585,7 +14585,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
 "QC" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/tdome/observation)
 "QD" = (
 /obj/structure/closet,
@@ -15254,7 +15254,7 @@
 /area/centcom/central_command_areas/admin)
 "Sx" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/admin/storage)
 "Sy" = (
 /obj/machinery/light/small/directional/north,
@@ -15876,7 +15876,7 @@
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "Ue" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "Uf" = (
 /obj/structure/table/reinforced,
@@ -16039,7 +16039,7 @@
 /turf/open/floor/wood/tile,
 /area/centcom/syndicate_mothership/control)
 "Uu" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership)
 "Uv" = (
 /obj/structure/table/reinforced,
@@ -16432,7 +16432,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "Vx" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/fore)
 "Vy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16822,7 +16822,7 @@
 /area/centcom/central_command_areas/holding)
 "Wx" = (
 /obj/machinery/vending/boozeomat,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/control)
 "Wy" = (
 /obj/structure/chair/office,
@@ -17421,7 +17421,7 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Ya" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/armory)
 "Yc" = (
 /obj/structure/fireplace,
@@ -17459,7 +17459,7 @@
 /area/centcom/syndicate_mothership/control)
 "Yg" = (
 /obj/effect/baseturf_helper/asteroid/snow,
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "Yj" = (
 /obj/structure/chair/comfy/black,
@@ -17497,7 +17497,7 @@
 /turf/open/misc/asteroid,
 /area/centcom/central_command_areas/control)
 "Yn" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/supplypod)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -17711,7 +17711,7 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/tdome/observation)
 "YU" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/admin/storage)
 "YV" = (
 /obj/structure/closet/lawcloset,
@@ -17733,7 +17733,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "YX" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/prison/cells)
 "YY" = (
 /obj/item/storage/medkit/toxin,
@@ -17759,7 +17759,7 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "Za" = (
 /obj/structure/sign/nanotrasen,
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/centcom/central_command_areas/fore)
 "Zb" = (
 /obj/machinery/door/poddoor/shuttledock{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -34504,7 +34504,7 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "mpF" = (
-/turf/closed/indestructible/riveted{
+/turf/closed/wall/indestructible/reinforced{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
 	name = "hyper-reinforced wall"
 	},

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -41,7 +41,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ag" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/shuttle/escape/luxury)
 "ah" = (
 /obj/effect/turf_decal/delivery,
@@ -113,7 +113,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "ay" = (
-/turf/closed/indestructible/syndicate,
+/turf/closed/wall/indestructible/reinforced/syndicate,
 /area/shuttle/escape/luxury)
 "az" = (
 /obj/machinery/computer/communications{

--- a/_maps/templates/admin_thunderdome.dmm
+++ b/_maps/templates/admin_thunderdome.dmm
@@ -139,7 +139,7 @@
 /turf/open/floor/iron,
 /area/template_noop)
 "v" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/template_noop)
 "w" = (
 /obj/structure/rack,

--- a/_maps/templates/heretic_sacrifice_template.dmm
+++ b/_maps/templates/heretic_sacrifice_template.dmm
@@ -344,7 +344,7 @@
 /turf/open/misc/ironsand,
 /area/centcom/heretic_sacrifice/rust)
 "Fd" = (
-/turf/closed/indestructible/riveted,
+/turf/closed/wall/indestructible/reinforced,
 /area/space)
 "Gl" = (
 /obj/structure/stone_tile/block/burnt{
@@ -446,7 +446,7 @@
 	},
 /area/centcom/heretic_sacrifice/ash)
 "La" = (
-/turf/closed/indestructible/riveted/plastinum,
+/turf/closed/wall/indestructible/reinforced/plastinum,
 /area/centcom/heretic_sacrifice/void)
 "LA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -628,7 +628,7 @@
 /turf/open/indestructible/necropolis/air,
 /area/centcom/heretic_sacrifice/flesh)
 "ZA" = (
-/turf/closed/indestructible/riveted/boss,
+/turf/closed/wall/indestructible/reinforced/boss,
 /area/centcom/heretic_sacrifice/ash)
 
 (1,1,1) = {"

--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -95,7 +95,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 #define SMOOTH_GROUP_SURVIVAL_TITANIUM_WALLS S_TURF(53) ///turf/closed/wall/mineral/titanium/survival
 #define SMOOTH_GROUP_HOTEL_WALLS S_TURF(54) ///turf/closed/indestructible/hotelwall
 #define SMOOTH_GROUP_MINERAL_WALLS S_TURF(55) ///turf/closed/mineral, /turf/closed/indestructible
-#define SMOOTH_GROUP_BOSS_WALLS S_TURF(56) ///turf/closed/indestructible/riveted/boss
+#define SMOOTH_GROUP_BOSS_WALLS S_TURF(56) ///turf/closed/wall/indestructible/reinforced/boss
 
 #define MAX_S_TURF SMOOTH_GROUP_BOSS_WALLS //Always match this value with the one above it.
 

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -74,12 +74,16 @@
  * Arguments:
  * * target - The atom we're trying to smooth with.
  */
-/atom/proc/can_area_smooth(target)
+/atom/proc/can_area_smooth(atom/target)
 	var/area/target_area = get_area(target)
 	var/area/source_area = get_area(src)
-	if((!source_area.area_limited_icon_smoothing || istype(target_area, source_area.area_limited_icon_smoothing)) && (!target_area.area_limited_icon_smoothing || istype(source_area, target_area.area_limited_icon_smoothing)))
-		return TRUE
-	return FALSE
+	if(!target_area)
+		return FALSE
+	if(target_area.area_limited_icon_smoothing && !istype(source_area, target_area.area_limited_icon_smoothing))
+		return FALSE
+	if(source_area.area_limited_icon_smoothing && !istype(target_area, source_area.area_limited_icon_smoothing))
+		return FALSE
+	return TRUE
 
 ///Scans all adjacent turfs to find targets to smooth with.
 /atom/proc/calculate_adjacencies()

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -97,8 +97,8 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 /datum/material/uranium
 	name = "uranium"
 	desc = "Uranium"
-	color = rgb(48, 237, 26)
-	greyscale_colors = rgb(48, 237, 26)
+	color = rgb(0, 122, 0)
+	greyscale_colors = rgb(0, 122, 0)
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	value_per_unit = 0.05
@@ -107,6 +107,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	wall_greyscale_config = /datum/greyscale_config/stone_wall
 	wall_type = /turf/closed/wall/mineral/uranium
 	false_wall_type = /obj/structure/falsewall/uranium
+	wall_greyscale_config = /datum/greyscale_config/stone_wall
 
 /datum/material/uranium/on_applied(atom/source, amount, material_flags)
 	. = ..()

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -259,7 +259,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	base_icon_state = "wall"
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SHUTTERS_BLASTDOORS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_LOW_WALL)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SHUTTERS_BLASTDOORS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_LOW_WALL, SMOOTH_GROUP_WINDOW_FULLTILE)
 
 	reinf_material = /datum/material/iron
 	plating_material = /datum/material/alloy/plasteel

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -259,7 +259,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	base_icon_state = "wall"
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SHUTTERS_BLASTDOORS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_LOW_WALL, SMOOTH_GROUP_WINDOW_FULLTILE)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_LOW_WALL, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTERS_BLASTDOORS)
 
 	reinf_material = /datum/material/iron
 	plating_material = /datum/material/alloy/plasteel

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -50,6 +50,134 @@
 	baseturfs = /turf/closed/indestructible/sandstone
 	smoothing_flags = SMOOTH_BITMASK
 
+
+/turf/closed/indestructible/alien
+	name = "alien wall"
+	desc = "A wall with alien alloy plating."
+	icon = 'icons/turf/walls/legacy/abductor_wall.dmi'
+	icon_state = "abductor_wall-0"
+	base_icon_state = "abductor_wall"
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+
+/turf/closed/indestructible/abductor
+	icon_state = "alien1"
+
+/turf/closed/indestructible/opshuttle
+	icon_state = "wall3"
+
+/turf/closed/indestructible/cult
+	name = "runed metal wall"
+	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound. Effectively impervious to conventional methods of destruction."
+	icon = 'icons/turf/walls/legacy/cult_wall.dmi'
+	icon_state = "cult_wall-0"
+	base_icon_state = "cult_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+
+/turf/closed/indestructible/fakedoor
+	name = "CentCom Access"
+	icon = 'icons/obj/doors/airlocks/centcom/airlock.dmi'
+	icon_state = "fake_door"
+
+/turf/closed/indestructible/rock
+	name = "dense rock"
+	desc = "An extremely densely-packed rock, most mining tools or explosives would never get through this."
+	icon = 'icons/turf/mining.dmi'
+	icon_state = "rock"
+
+/turf/closed/indestructible/rock/snow
+	name = "mountainside"
+	desc = "An extremely densely-packed rock, sheeted over with centuries worth of ice and snow."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "snowrock"
+	bullet_sizzle = TRUE
+	bullet_bounce_sound = null
+
+/turf/closed/indestructible/rock/snow/ice
+	name = "iced rock"
+	desc = "Extremely densely-packed sheets of ice and rock, forged over the years of the harsh cold."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "icerock"
+
+/turf/closed/indestructible/rock/snow/ice/ore
+	icon = 'icons/turf/walls/legacy/icerock_wall.dmi'
+	icon_state = "icerock_wall-0"
+	base_icon_state = "icerock_wall"
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
+	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
+	pixel_x = -4
+	pixel_y = -4
+
+/turf/closed/indestructible/wood
+	icon = 'icons/turf/walls/legacy/wood_wall.dmi'
+	icon_state = "wood_wall-0"
+	base_icon_state = "wood_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+
+/turf/closed/indestructible/paper
+	name = "thick paper wall"
+	desc = "A wall layered with impenetrable sheets of paper."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "paperwall"
+
+/turf/closed/indestructible/necropolis
+	name = "necropolis wall"
+	desc = "A seemingly impenetrable wall."
+	icon = 'icons/turf/walls.dmi'
+	icon_state = "necro"
+	explosion_block = 50
+	baseturfs = /turf/closed/indestructible/necropolis
+
+/turf/closed/indestructible/necropolis/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "necro1"
+	return TRUE
+
+/turf/closed/indestructible/iron
+	name = "impervious iron wall"
+	desc = "A wall with tough iron plating."
+	icon = 'icons/turf/walls/legacy/iron_wall.dmi'
+	icon_state = "iron_wall-0"
+	base_icon_state = "iron_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+	opacity = FALSE
+
+/turf/closed/indestructible/boss
+	name = "necropolis wall"
+	desc = "A thick, seemingly indestructible stone wall."
+	icon = 'icons/turf/walls/legacy/boss_wall.dmi'
+	icon_state = "boss_wall-0"
+	base_icon_state = "boss_wall"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_BOSS_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_BOSS_WALLS)
+	explosion_block = 50
+	baseturfs = /turf/closed/wall/indestructible/reinforced/boss
+
+/turf/closed/wall/indestructible/reinforced/boss/see_through
+	opacity = FALSE
+
+/turf/closed/wall/indestructible/reinforced/boss/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
+	underlay_appearance.icon = 'icons/turf/floors.dmi'
+	underlay_appearance.icon_state = "basalt"
+	return TRUE
+
+/turf/closed/indestructible/hierophant
+	name = "wall"
+	desc = "A wall made out of a strange metal. The squares on it pulse in a predictable pattern."
+	icon = 'icons/turf/walls/legacy/hierophant_wall.dmi'
+	icon_state = "wall"
+	smoothing_flags = SMOOTH_CORNERS
+	smoothing_groups = list(SMOOTH_GROUP_HIERO_WALL)
+	canSmoothWith = list(SMOOTH_GROUP_HIERO_WALL)
+
+
 /turf/closed/indestructible/oldshuttle/corner
 	icon_state = "corner"
 
@@ -93,82 +221,63 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	desc = null
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-/turf/closed/indestructible/reinforced
+
+//Walls that will be greyscaled
+/turf/closed/wall/indestructible
 	name = "reinforced wall"
 	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/legacy/reinforced_wall.dmi'
-	icon_state = "reinforced_wall-0"
-	base_icon_state = "reinforced_wall"
+	explosion_block = 50
+
+/turf/closed/wall/indestructible/rust_heretic_act()
+	return
+
+/turf/closed/wall/indestructible/TerraformTurf(path, new_baseturf, flags, defer_change = FALSE, ignore_air = FALSE)
+	return
+
+/turf/closed/wall/indestructible/acid_act(acidpwr, acid_volume, acid_id)
+	return FALSE
+
+/turf/closed/wall/indestructible/Melt()
+	to_be_destroyed = FALSE
+	return src
+
+/turf/closed/wall/indestructible/singularity_act()
+	return
+
+/turf/closed/wall/indestructible/uranium
+	icon = 'icons/turf/walls/stone_wall.dmi'
+	desc = "A wall with uranium plating. This is probably a bad idea. Effectively impervious to conventional methods of destruction."
+	smoothing_flags = SMOOTH_BITMASK
+	plating_material = /datum/material/uranium
+	color = "#007a00" //To display in mapping softwares
+
+/turf/closed/wall/indestructible/reinforced
+	name = "reinforced wall"
+	desc = "A huge chunk of reinforced metal used to separate rooms. Effectively impervious to conventional methods of destruction."
+	icon = 'icons/turf/walls/solid_wall_reinforced.dmi'
+	icon_state = "wall-0"
+	base_icon_state = "wall"
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
+	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_SHUTTERS_BLASTDOORS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_LOW_WALL)
 
+	reinf_material = /datum/material/iron
+	plating_material = /datum/material/alloy/plasteel
 
-/turf/closed/indestructible/riveted
-	icon = 'icons/turf/walls/legacy/riveted.dmi'
-	icon_state = "riveted-0"
-	base_icon_state = "riveted"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS)
-	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
-
-/turf/closed/indestructible/syndicate
-	icon = 'icons/turf/walls/legacy/plastitanium_wall.dmi'
-	icon_state = "plastitanium_wall-0"
-	base_icon_state = "plastitanium_wall"
+/turf/closed/wall/indestructible/reinforced/syndicate
+	icon = 'icons/turf/walls/metal_wall.dmi'
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTLE_PARTS)
 
-/turf/closed/indestructible/riveted/uranium
-	icon = 'icons/turf/walls/legacy/uranium_wall.dmi'
-	icon_state = "uranium_wall-0"
-	base_icon_state = "uranium_wall"
-	smoothing_flags = SMOOTH_BITMASK
+	reinf_material = /datum/material/iron
+	plating_material = /datum/material/alloy/plastitanium
+	color = "#3a313a" //To display in mapping softwares
 
-/turf/closed/indestructible/riveted/plastinum
+/turf/closed/wall/indestructible/reinforced/plastinum
 	name = "plastinum wall"
 	desc = "A luxurious wall made out of a plasma-platinum alloy. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/legacy/plastinum_wall.dmi'
-	icon_state = "plastinum_wall-0"
-	base_icon_state = "plastinum_wall"
-
-/turf/closed/indestructible/wood
-	icon = 'icons/turf/walls/legacy/wood_wall.dmi'
-	icon_state = "wood_wall-0"
-	base_icon_state = "wood_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-
-
-/turf/closed/indestructible/alien
-	name = "alien wall"
-	desc = "A wall with alien alloy plating."
-	icon = 'icons/turf/walls/legacy/abductor_wall.dmi'
-	icon_state = "abductor_wall-0"
-	base_icon_state = "abductor_wall"
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-
-
-/turf/closed/indestructible/cult
-	name = "runed metal wall"
-	desc = "A cold metal wall engraved with indecipherable symbols. Studying them causes your head to pound. Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/legacy/cult_wall.dmi'
-	icon_state = "cult_wall-0"
-	base_icon_state = "cult_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-
-
-/turf/closed/indestructible/abductor
-	icon_state = "alien1"
-
-/turf/closed/indestructible/opshuttle
-	icon_state = "wall3"
-
+	color = "#b3c0c7" //To display in mapping softwares
 
 /turf/closed/indestructible/fakeglass
 	name = "window"
@@ -194,7 +303,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	color = "#5d3369"
 	opacity = FALSE
 	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM, SMOOTH_GROUP_SHUTTLE_PARTS)
+	smoothing_groups = list(SMOOTH_GROUP_SHUTTLE_PARTS, SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM)
 	canSmoothWith = list(SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM)
 
 /turf/closed/indestructible/opsglass/Initialize(mapload, inherited_virtual_z)
@@ -202,97 +311,3 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	icon_state = null
 	underlays += mutable_appearance('icons/obj/structures.dmi', "grille")
 	underlays += mutable_appearance('icons/turf/floors.dmi', "plating")
-
-/turf/closed/indestructible/fakedoor
-	name = "CentCom Access"
-	icon = 'icons/obj/doors/airlocks/centcom/airlock.dmi'
-	icon_state = "fake_door"
-
-/turf/closed/indestructible/rock
-	name = "dense rock"
-	desc = "An extremely densely-packed rock, most mining tools or explosives would never get through this."
-	icon = 'icons/turf/mining.dmi'
-	icon_state = "rock"
-
-/turf/closed/indestructible/rock/snow
-	name = "mountainside"
-	desc = "An extremely densely-packed rock, sheeted over with centuries worth of ice and snow."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "snowrock"
-	bullet_sizzle = TRUE
-	bullet_bounce_sound = null
-
-/turf/closed/indestructible/rock/snow/ice
-	name = "iced rock"
-	desc = "Extremely densely-packed sheets of ice and rock, forged over the years of the harsh cold."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "icerock"
-
-/turf/closed/indestructible/rock/snow/ice/ore
-	icon = 'icons/turf/walls/legacy/icerock_wall.dmi'
-	icon_state = "icerock_wall-0"
-	base_icon_state = "icerock_wall"
-	smoothing_flags = SMOOTH_BITMASK | SMOOTH_BORDER
-	canSmoothWith = list(SMOOTH_GROUP_CLOSED_TURFS)
-	pixel_x = -4
-	pixel_y = -4
-
-
-/turf/closed/indestructible/paper
-	name = "thick paper wall"
-	desc = "A wall layered with impenetrable sheets of paper."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "paperwall"
-
-/turf/closed/indestructible/necropolis
-	name = "necropolis wall"
-	desc = "A seemingly impenetrable wall."
-	icon = 'icons/turf/walls.dmi'
-	icon_state = "necro"
-	explosion_block = 50
-	baseturfs = /turf/closed/indestructible/necropolis
-
-/turf/closed/indestructible/necropolis/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "necro1"
-	return TRUE
-
-/turf/closed/indestructible/iron
-	name = "impervious iron wall"
-	desc = "A wall with tough iron plating."
-	icon = 'icons/turf/walls/legacy/iron_wall.dmi'
-	icon_state = "iron_wall-0"
-	base_icon_state = "iron_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_WALLS)
-	opacity = FALSE
-
-/turf/closed/indestructible/riveted/boss
-	name = "necropolis wall"
-	desc = "A thick, seemingly indestructible stone wall."
-	icon = 'icons/turf/walls/legacy/boss_wall.dmi'
-	icon_state = "boss_wall-0"
-	base_icon_state = "boss_wall"
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_CLOSED_TURFS, SMOOTH_GROUP_BOSS_WALLS)
-	canSmoothWith = list(SMOOTH_GROUP_BOSS_WALLS)
-	explosion_block = 50
-	baseturfs = /turf/closed/indestructible/riveted/boss
-
-/turf/closed/indestructible/riveted/boss/see_through
-	opacity = FALSE
-
-/turf/closed/indestructible/riveted/boss/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
-	underlay_appearance.icon = 'icons/turf/floors.dmi'
-	underlay_appearance.icon_state = "basalt"
-	return TRUE
-
-/turf/closed/indestructible/riveted/hierophant
-	name = "wall"
-	desc = "A wall made out of a strange metal. The squares on it pulse in a predictable pattern."
-	icon = 'icons/turf/walls/legacy/hierophant_wall.dmi'
-	icon_state = "wall"
-	smoothing_flags = SMOOTH_CORNERS
-	smoothing_groups = list(SMOOTH_GROUP_HIERO_WALL)
-	canSmoothWith = list(SMOOTH_GROUP_HIERO_WALL)

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -303,7 +303,7 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	color = "#5d3369"
 	opacity = FALSE
 	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = list(SMOOTH_GROUP_SHUTTLE_PARTS, SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM)
+	smoothing_groups = list(SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM, SMOOTH_GROUP_SHUTTLE_PARTS)
 	canSmoothWith = list(SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM)
 
 /turf/closed/indestructible/opsglass/Initialize(mapload, inherited_virtual_z)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -46,6 +46,9 @@
 	article = "a"
 	name = "uranium wall"
 	desc = "A wall with uranium plating. This is probably a bad idea."
+	icon = 'icons/turf/walls/stone_wall.dmi'
+	plating_material = /datum/material/uranium
+	color = "#007a00" //To display in mapping softwares
 
 	/// Mutex to prevent infinite recursion when propagating radiation pulses
 	var/active = null


### PR DESCRIPTION
## About The Pull Request
Port of: https://github.com/pariahstation/Pariah-Station/pull/816 Makes the walls at Centcom also be 3/4 perspective like the rest of the walls on the station and shuttles we use.

## How Does This Help ***Gameplay***?
Prettier walls to look at that aren't ugly or out of place, Yippie!

## How Does This Help ***Roleplay***?
Minimal impact on roleplaying.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

### Old Centcom walls
![](https://i.gyazo.com/7a495a1a001aea9a36e1b4fc12018f1c.png)

### New Centcom walls
![](https://i.gyazo.com/00ff94f5a5ee2640942bdf0ed7dee5de.png)

</details>

## Changelog
:cl:
add: 3/4 Centcom walls.
/:cl: