### PR TITLE
[PORT] Ports Logarithmic audio volume from Horizon

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -25,6 +25,14 @@
 
 #define CHANNEL_HIGHEST_AVAILABLE 1015
 
+// TODO: This is currently set to 2 because of legacy audio volumes. Re-balance all audio with a target of NUM_E or 3
+/// Logarithmic exponent for volume levels - Good values are 2, NUM_E, 3 and 4, depending on loudness.
+#define LOGARITHMIC_AUDIO_VOLUME_EXPONENT 2
+// I hate the following but my smooth brain can't come up with a better way to multiply this correctly.
+// (x²) * 0.01 would work, but the multiplier is dependent on the exponent.
+/// Helper macro for converting linear volume to logarithmic.
+#define LOG_AUDIOVOLUME(X) (((X * 0.01) ** LOGARITHMIC_AUDIO_VOLUME_EXPONENT) * 100)
+
 #define MAX_INSTRUMENT_CHANNELS (128 * 6)
 
 #define SOUND_MINIMUM_PRESSURE 10

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -218,7 +218,7 @@
 	for(var/client/C in GLOB.clients)
 		if(!C?.credits)
 			C?.RollCredits()
-		C?.playtitlemusic(40)
+		C?.playtitlemusic()
 		if(speed_round)
 			C?.give_award(/datum/award/achievement/misc/speed_round, C?.mob)
 		HandleRandomHardcoreScore(C)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,4 +1,4 @@
-
+#define LOBBYMUSIC_VOLUME 30
 ///Default override for echo
 /sound
 	echo = list(
@@ -171,12 +171,12 @@
 	S.status = SOUND_UPDATE
 	SEND_SOUND(src, S)
 
-/client/proc/playtitlemusic(vol = 85)
+/client/proc/playtitlemusic(vol = LOBBYMUSIC_VOLUME)
 	set waitfor = FALSE
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY) && !CONFIG_GET(flag/disallow_title_music))
-		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
+		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = LOG_AUDIOVOLUME(vol), channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.
@@ -249,3 +249,5 @@
 			if(SFX_ROCK_TAP)
 				soundin = pick('sound/effects/rocktap1.ogg', 'sound/effects/rocktap2.ogg', 'sound/effects/rocktap3.ogg')
 	return soundin
+
+#undef LOBBYMUSIC_VOLUME


### PR DESCRIPTION
## About The Pull Request
As the title suggests this ports logarithmic audio from Horizon. https://github.com/hrzntal/horizon/pull/900

See the original PR for more details.

## How Does This Help ***Gameplay***?
You no longer go deaf from sounds and everything doesn't feel like its played at max volume anymore 🥳 

## How Does This Help ***Roleplay***?
Minimal impact on roleplaying.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![](https://i.gyazo.com/03a91e9715a556c504b3bc7c74df46a3.png)

### Current Sound
https://user-images.githubusercontent.com/79924768/225570519-4968803e-a6bd-400d-af93-2b8623fb126a.mp4

### Sound after this PR
https://user-images.githubusercontent.com/79924768/225569423-4ea2c242-2d04-4b6b-a0b9-63a4480e973d.mp4

</details>

## Changelog

:cl:
qol: Made sound nicer so you no longer go deaf.
/:cl: