### PR TITLE
[PORT] Ports Prefs Load VV option from Skyrat

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -143,6 +143,7 @@
 #define VV_HK_MOD_QUIRKS "quirkmod"
 #define VV_HK_SET_SPECIES "setspecies"
 #define VV_HK_PURRBATION "purrbation"
+#define VV_HK_LOAD_PREFS "load_prefs"
 
 // misc
 #define VV_HK_SPACEVINE_PURGE "spacevine_purge"

--- a/code/modules/admin/view_variables/load_prefs.dm
+++ b/code/modules/admin/view_variables/load_prefs.dm
@@ -1,0 +1,20 @@
+/mob/proc/vv_load_prefs()
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(!client)
+		to_chat(usr, span_warning("No client found!"))
+		return
+
+	if(!ishuman(src))
+		to_chat(usr, span_warning("Mob is not human!"))
+		return
+
+	var/notice = tgui_alert(usr, "Are you sure you want to load the clients current prefs onto their mob?", "Load Preferences", list("Yes", "No"))
+	if(notice != "Yes")
+		return
+
+	client?.prefs?.apply_prefs_to(src)
+	var/msg = span_notice("[key_name_admin(usr)] has loaded [key_name(src)]'s preferences onto their current mob [ADMIN_VERBOSEJMP(src)].")
+	message_admins(msg)
+	admin_ticket_log(src, msg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1220,6 +1220,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_DIRECT_CONTROL, "Assume Direct Control")
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_DIRECT_CONTROL, "Give Direct Control")
 	VV_DROPDOWN_OPTION(VV_HK_OFFER_GHOSTS, "Offer Control to Ghosts")
+	VV_DROPDOWN_OPTION(VV_HK_LOAD_PREFS, "Load Prefs Onto Mob")
 
 /mob/vv_do_topic(list/href_list)
 	. = ..()
@@ -1271,6 +1272,10 @@
 		if(!check_rights(NONE))
 			return
 		offer_control(src)
+	if(href_list[VV_HK_LOAD_PREFS])
+		if(!check_rights(NONE))
+			return
+		vv_load_prefs(src)
 
 /**
  * extra var handling for the logging var

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2174,6 +2174,7 @@
 #include "code\modules\admin\view_variables\debug_variables.dm"
 #include "code\modules\admin\view_variables\filterrific.dm"
 #include "code\modules\admin\view_variables\get_variables.dm"
+#include "code\modules\admin\view_variables\load_prefs.dm"
 #include "code\modules\admin\view_variables\mark_datum.dm"
 #include "code\modules\admin\view_variables\mass_edit_variables.dm"
 #include "code\modules\admin\view_variables\modify_variables.dm"


### PR DESCRIPTION
## About The Pull Request
Port of: https://github.com/Skyrat-SS13/Skyrat-tg/pull/16682

This will allow admins to override a mob their prefs with the ones they currently have loaded.

## How Does This Help ***Gameplay***?
Handy for admins to do stuff with but no real impact on normal gameplay

## How Does This Help ***Roleplay***?
Minimal impact on roleplay

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/226178468-c87fdd32-0051-458d-bf1b-4c26deee2c15.mp4

</details>

## Changelog
:cl:
admin: Added a VV option for loading prefs onto a mob.
/:cl: