### PR TITLE
[FUCK] Fixes Transit Handlers Forcing Atoms to Harddel

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
+//#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -1,4 +1,4 @@
-//#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
+#define TESTING //By using the testing("message") proc you can create debug-feedback for people with this
 								//uncommented, but not visible in the release version)
 
 //#define DATUMVAR_DEBUGGING_MODE //Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
@@ -12,12 +12,12 @@
 #define DATUMVAR_DEBUGGING_MODE
 
 ///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
-//#define REFERENCE_TRACKING
+#define REFERENCE_TRACKING
 #ifdef REFERENCE_TRACKING
 
 ///Used for doing dry runs of the reference finder, to test for feature completeness
 ///Slightly slower, higher in memory. Just not optimal
-//#define REFERENCE_TRACKING_DEBUG
+#define REFERENCE_TRACKING_DEBUG
 
 ///Run a lookup on things hard deleting by default.
 //#define GC_FAILURE_HARD_LOOKUP
@@ -38,7 +38,7 @@
 // Displays static object lighting updates
 // Also enables some debug vars on sslighting that can be used to modify
 // How extensively we prune lighting corners to update
-#define VISUALIZE_LIGHT_UPDATES
+//#define VISUALIZE_LIGHT_UPDATES
 
 #define VISUALIZE_ACTIVE_TURFS //Highlights atmos active turfs in green
 #define TRACK_MAX_SHARE //Allows max share tracking, for use in the atmos debugging ui

--- a/code/datums/components/transit_handler.dm
+++ b/code/datums/components/transit_handler.dm
@@ -8,6 +8,7 @@
 	transit_instance = transit_instance_
 	transit_instance.affected_movables[parent] = TRUE
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_parent_moved))
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_qdel))
 
 /datum/component/transit_handler/proc/on_parent_moved(atom/movable/source, atom/old_loc, Dir, Forced)
 	var/turf/new_location = get_turf(parent)
@@ -19,3 +20,7 @@
 	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
 	transit_instance.affected_movables -= parent
 	return ..()
+
+/datum/component/transit_handler/proc/handle_parent_qdel()
+	SIGNAL_HANDLER
+	qdel(src)

--- a/code/datums/components/transit_handler.dm
+++ b/code/datums/components/transit_handler.dm
@@ -23,4 +23,7 @@
 
 /datum/component/transit_handler/proc/handle_parent_qdel()
 	SIGNAL_HANDLER
+	if(parent)
+		UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+	ClearFromParent()
 	qdel(src)

--- a/code/datums/components/transit_handler.dm
+++ b/code/datums/components/transit_handler.dm
@@ -2,10 +2,10 @@
 	/// Our transit instance
 	var/datum/transit_instance/transit_instance
 
-/datum/component/transit_handler/Initialize(datum/transit_instance/transit_instance_)
+/datum/component/transit_handler/Initialize(datum/transit_instance/transit_instance)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
-	transit_instance = transit_instance_
+	src.transit_instance = transit_instance
 	transit_instance.affected_movables[parent] = TRUE
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_parent_moved))
 	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_qdel))
@@ -17,13 +17,11 @@
 	transit_instance.MovableMoved(parent)
 
 /datum/component/transit_handler/Destroy()
-	UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+	ClearFromParent()
 	transit_instance.affected_movables -= parent
 	return ..()
 
 /datum/component/transit_handler/proc/handle_parent_qdel()
 	SIGNAL_HANDLER
-	if(parent)
-		UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
-	ClearFromParent()
 	qdel(src)

--- a/code/datums/components/transit_handler.dm
+++ b/code/datums/components/transit_handler.dm
@@ -17,9 +17,9 @@
 	transit_instance.MovableMoved(parent)
 
 /datum/component/transit_handler/Destroy()
+	transit_instance.affected_movables -= parent
 	UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
 	ClearFromParent()
-	transit_instance.affected_movables -= parent
 	return ..()
 
 /datum/component/transit_handler/proc/handle_parent_qdel()

--- a/code/datums/transit_instance.dm
+++ b/code/datums/transit_instance.dm
@@ -49,10 +49,7 @@
 
 //Movable moved in transit
 /datum/transit_instance/proc/MovableMoved(atom/movable/moved)
-	if(!moved)
-		stack_trace("null movable on Movable Moved in Transit Instance")
-		return
-	if(!moved.loc || !isturf(moved.loc))
+	if(!moved?.loc || !isturf(moved.loc))
 		return
 	var/turf/my_turf = moved.loc
 	if(!reservation.IsAdjacentToEdgeOrOutOfBounds(my_turf))

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -50,6 +50,11 @@ GLOBAL_LIST_EMPTY(default_lighting_underlays_by_z)
 	return ..()
 
 /datum/lighting_object/proc/update()
+#ifdef VISUALIZE_LIGHT_UPDATES
+	affected_turf.add_atom_colour(COLOR_BLUE_LIGHT, ADMIN_COLOUR_PRIORITY)
+	animate(affected_turf, 10, color = null)
+	addtimer(CALLBACK(affected_turf, /atom/proc/remove_atom_colour, ADMIN_COLOUR_PRIORITY, COLOR_BLUE_LIGHT), 10, TIMER_UNIQUE|TIMER_OVERRIDE)
+#endif
 
 	// To the future coder who sees this and thinks
 	// "Why didn't he just use a loop?"

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -50,11 +50,6 @@ GLOBAL_LIST_EMPTY(default_lighting_underlays_by_z)
 	return ..()
 
 /datum/lighting_object/proc/update()
-#ifdef VISUALIZE_LIGHT_UPDATES
-	affected_turf.add_atom_colour(COLOR_BLUE_LIGHT, ADMIN_COLOUR_PRIORITY)
-	animate(affected_turf, 10, color = null)
-	addtimer(CALLBACK(affected_turf, /atom/proc/remove_atom_colour, ADMIN_COLOUR_PRIORITY, COLOR_BLUE_LIGHT), 10, TIMER_UNIQUE|TIMER_OVERRIDE)
-#endif
 
 	// To the future coder who sees this and thinks
 	// "Why didn't he just use a loop?"

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -126,18 +126,20 @@ GLOBAL_LIST_INIT(meteorsD, list(/obj/effect/meteor/medium=15, /obj/effect/meteor
 	var/signature = "motion"
 	var/del_timer
 
-/obj/effect/meteor/Initialize(mapload, turf/target)
+/obj/effect/meteor/Initialize(mapload, target)
 	. = ..()
 	z_original = z
 	GLOB.meteor_list += src
 	SSaugury.register_doom(src, threat)
 	SpinAnimation()
+	del_timer = QDEL_IN(src, lifetime)
+	dest = target
 	chase_target(target)
 
 /obj/effect/meteor/Destroy()
+	GLOB.meteor_list -= src
 	if (del_timer)
 		deltimer(del_timer)
-	GLOB.meteor_list -= src
 	return ..()
 
 /obj/effect/meteor/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
@@ -158,16 +160,6 @@ GLOBAL_LIST_INIT(meteorsD, list(/obj/effect/meteor/medium=15, /obj/effect/meteor
 
 /obj/effect/meteor/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	return TRUE //Keeps us from drifting for no reason
-
-/obj/effect/meteor/Initialize(mapload, target)
-	. = ..()
-	z_original = z
-	GLOB.meteor_list += src
-	SSaugury.register_doom(src, threat)
-	SpinAnimation()
-	del_timer = QDEL_IN(src, lifetime)
-	dest = target
-	chase_target(target)
 
 /obj/effect/meteor/Bump(atom/A)
 	. = ..() //What could go wrong


### PR DESCRIPTION
## About The Pull Request

I AM A GOOD CODER, I AM A SMART CODER, AND I SWEAR I CAN CHERRY PICK WITHOUT FUCKING EVERYTHING UP.

Should fix CI.

Also changes _compile_options.dm to enable full reftracking without extra edits when testing is enabled.

Also fixes a runtime with nulls being passed into `transit_instance.MovableMoved`

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/226430454-35c30da0-8f46-4af2-a5d9-8071bda09333.png)
First harddel pass, as you can see, it no longer has a *huge* list of harddel'd items, instead just some harddels related to a completely different bug.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed transit handlers causing harddels.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
