### PR TITLE
[PORT] Fixes Guests Not Having Keybinds

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -168,19 +168,19 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	apply_all_client_preferences()
 
 	//general preferences
-	lastchangelog = savefile.get_entry("lastchangelog")
-	be_special = savefile.get_entry("be_special")
-	default_slot = savefile.get_entry("default_slot")
-	chat_toggles = savefile.get_entry("chat_toggles")
-	toggles = savefile.get_entry("toggles")
-	ignoring = savefile.get_entry("ignoring")
+	lastchangelog = savefile.get_entry("lastchangelog", lastchangelog)
+	be_special = savefile.get_entry("be_special", be_special)
+	default_slot = savefile.get_entry("default_slot", default_slot)
+	chat_toggles = savefile.get_entry("chat_toggles", chat_toggles)
+	toggles = savefile.get_entry("toggles", toggles)
+	ignoring = savefile.get_entry("ignoring", ignoring)
 
 	// OOC commendations
-	hearted_until = savefile.get_entry("hearted_until")
+	hearted_until = savefile.get_entry("hearted_until", hearted_until)
 	if(hearted_until > world.realtime)
 		hearted = TRUE
 	//favorite outfits
-	favorite_outfits = savefile.get_entry("favorite_outfits")
+	favorite_outfits = savefile.get_entry("favorite_outfits", favorite_outfits)
 
 	var/list/parsed_favs = list()
 	for(var/typetext in favorite_outfits)
@@ -190,7 +190,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	favorite_outfits = unique_list(parsed_favs)
 
 	// Custom hotkeys
-	key_bindings = savefile.get_entry("key_bindings")
+	key_bindings = savefile.get_entry("key_bindings", key_bindings)
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/72818

Fixes guest accounts being unable to move. Completely irrelevant on the server, but this actually makes testing scenarios where a second player is needed way harder.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/226977939-1cc96902-43c7-4743-aa25-27b550a09f2c.png)

</details>

## Changelog

:cl: ZephyrTFA (initial), RimiNosha (porter)
fix: Fixed guests being unable to move, not that anyone outside a dev environment would know.
/:cl:
