### PR TITLE
Fix Synth Antennae

### DIFF
--- a/code/modules/surgery/organs/external/antenna.dm
+++ b/code/modules/surgery/organs/external/antenna.dm
@@ -19,8 +19,7 @@
 /datum/bodypart_overlay/mutant/synth_antenna/override_color(obj/item/bodypart/bodypart)
 	return bodypart.owner.dna.features["[MUTANT_SYNTH_ANTENNA]_color"]
 
-
 /datum/bodypart_overlay/mutant/synth_antenna/can_draw_on_bodypart(mob/living/carbon/human/human)
-	if((human.head.flags_inv & HIDEEARS || human.wear_mask.flags_inv & HIDEEARS))
+	if(!human.head?.flags_inv & HIDEEARS && !human.wear_mask?.flags_inv & HIDEEARS)
 		return TRUE
 	return FALSE

--- a/code/modules/surgery/organs/external/antenna.dm
+++ b/code/modules/surgery/organs/external/antenna.dm
@@ -20,6 +20,6 @@
 	return bodypart.owner.dna.features["[MUTANT_SYNTH_ANTENNA]_color"]
 
 /datum/bodypart_overlay/mutant/synth_antenna/can_draw_on_bodypart(mob/living/carbon/human/human)
-	if(!human.head?.flags_inv & HIDEEARS && !human.wear_mask?.flags_inv & HIDEEARS)
+	if(!(human.head?.flags_inv & HIDEEARS) && !(human.wear_mask?.flags_inv & HIDEEARS))
 		return TRUE
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

Oops! Helps if I actually have the condition to render the right way around!

Makes synth antennae hidden while wearing something that obscures ears, and Fixes a runtime when not wearing a helmet and mask.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/229366161-c5f70130-5283-4f5e-86de-850ee9f6e636.png)

</details>

## Changelog

:cl:
fix: Synth antennae now show properly.
/:cl:
