### PR TITLE
[PORT] Adds Pixel shifting to the game!

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -90,3 +90,4 @@
 #define COMSIG_KB_MOVEMENT_EAST_DOWN "keybinding_movement_east_down"
 #define COMSIG_KB_MOVEMENT_ZLEVEL_MOVEUP_DOWN "keybinding_mob_zlevel_moveup_down"
 #define COMSIG_KB_MOVEMENT_ZLEVEL_MOVEDOWN_DOWN "keybinding_mob_zlevel_movedown_down"
+#define COMSIG_KB_MOB_PIXELSHIFT "keybinding_mob_pixelshift"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -233,7 +233,7 @@
 	return TRUE
 
 /datum/keybinding/mob/prevent_movement
-	hotkey_keys = list("Alt")
+	hotkey_keys = list("Ctrl")
 	name = "block_movement"
 	full_name = "Block movement"
 	description = "Prevents you from moving"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -233,7 +233,7 @@
 	return TRUE
 
 /datum/keybinding/mob/prevent_movement
-	hotkey_keys = list("Ctrl")
+	hotkey_keys = list("Alt")
 	name = "block_movement"
 	full_name = "Block movement"
 	description = "Prevents you from moving"

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -85,6 +85,11 @@
 		return FALSE
 	if(SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE) & COMSIG_MOB_CLIENT_BLOCK_PRE_LIVING_MOVE)
 		return FALSE
+	if(mob.shifting)
+		mob.pixel_shift(direct)
+		return FALSE
+	else if(mob.is_shifted)
+		mob.unpixel_shift()
 
 	var/mob/living/L = mob //Already checked for isliving earlier
 	if(L.incorporeal_move && !is_secret_level(mob.z)) //Move though walls

--- a/code/modules/pixel_shift/pixel_shift.dm
+++ b/code/modules/pixel_shift/pixel_shift.dm
@@ -1,0 +1,97 @@
+#define MAXIMUM_PIXEL_SHIFT 16
+#define PASSABLE_SHIFT_THRESHOLD 8
+
+/mob
+	/// Whether the mob is pixel shifted or not
+	var/is_shifted = FALSE
+	/// If we are in the shifting setting.
+	var/shifting = FALSE
+
+	/// Takes the four cardinal direction defines. Any atoms moving into this atom's tile will be allowed to from the added directions.
+	var/passthroughable = NONE
+
+/datum/keybinding/mob/pixel_shift
+	hotkey_keys = list("B")
+	name = "pixel_shift"
+	full_name = "Pixel Shift"
+	description = "Shift your characters offset."
+	category = CATEGORY_MOVEMENT
+	keybind_signal = COMSIG_KB_MOB_PIXELSHIFT
+
+/datum/keybinding/mob/pixel_shift/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/M = user.mob
+	M.shifting = TRUE
+	return TRUE
+
+/datum/keybinding/mob/pixel_shift/up(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/M = user.mob
+	M.shifting = FALSE
+	return TRUE
+
+/mob/proc/unpixel_shift()
+	return
+
+/mob/living/unpixel_shift()
+	. = ..()
+	passthroughable = NONE
+	if(is_shifted)
+		is_shifted = FALSE
+		pixel_x = body_position_pixel_x_offset + base_pixel_x
+		pixel_y = body_position_pixel_y_offset + base_pixel_y
+
+/mob/proc/pixel_shift(direction)
+	return
+
+/mob/living/set_pull_offsets(mob/living/pull_target, grab_state)
+	pull_target.unpixel_shift()
+	return ..()
+
+/mob/living/reset_pull_offsets(mob/living/pull_target, override)
+	pull_target.unpixel_shift()
+	return ..()
+
+/mob/living/pixel_shift(direction)
+	passthroughable = NONE
+	switch(direction)
+		if(NORTH)
+			if(pixel_y <= MAXIMUM_PIXEL_SHIFT + base_pixel_y)
+				pixel_y++
+				is_shifted = TRUE
+		if(EAST)
+			if(pixel_x <= MAXIMUM_PIXEL_SHIFT + base_pixel_x)
+				pixel_x++
+				is_shifted = TRUE
+		if(SOUTH)
+			if(pixel_y >= -MAXIMUM_PIXEL_SHIFT + base_pixel_y)
+				pixel_y--
+				is_shifted = TRUE
+		if(WEST)
+			if(pixel_x >= -MAXIMUM_PIXEL_SHIFT + base_pixel_x)
+				pixel_x--
+				is_shifted = TRUE
+
+	// Yes, I know this sets it to true for everything if more than one is matched.
+	// Movement doesn't check diagonals, and instead just checks EAST or WEST, depending on where you are for those.
+	if(pixel_y > PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= EAST | SOUTH | WEST
+	if(pixel_x > PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | SOUTH | WEST
+	if(pixel_y < -PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | EAST | WEST
+	if(pixel_x < -PASSABLE_SHIFT_THRESHOLD)
+		passthroughable |= NORTH | EAST | SOUTH
+
+/mob/living/CanAllowThrough(atom/movable/mover, border_dir)
+	// Make sure to not allow projectiles of any kind past where they normally wouldn't.
+	if(!istype(mover, /obj/projectile) && !mover.throwing && passthroughable & border_dir)
+		return TRUE
+	return ..()
+
+#undef MAXIMUM_PIXEL_SHIFT
+#undef PASSABLE_SHIFT_THRESHOLD

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4025,6 +4025,7 @@
 #include "code\modules\photography\photos\album.dm"
 #include "code\modules\photography\photos\frame.dm"
 #include "code\modules\photography\photos\photo.dm"
+#include "code\modules\pixel_shift\pixel_shift.dm"
 #include "code\modules\plumbing\ducts.dm"
 #include "code\modules\plumbing\plumbers\_plumb_machinery.dm"
 #include "code\modules\plumbing\plumbers\acclimator.dm"


### PR DESCRIPTION
## About The Pull Request
Does at it says in the title!

For those that dont know what Pixel shifting is, Pixel shifting allows you to move your character a certain amount of pixels within the tile they're standing in, this is great for roleplay purposes. The default Keybind for this is B. 

Ports the following PRs:
- https://github.com/Skyrat-SS13/Skyrat-tg/pull/870
- https://github.com/Skyrat-SS13/Skyrat-tg/pull/15175

## How Does This Help ***Gameplay***?
You can now pixelshift and if you shift far enough you can even move out of the way for others! (See testing video for example)

## How Does This Help ***Roleplay***?
I'm not gonna explain it but if you know you know.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/232329782-51cdaa30-9a9d-4d68-b446-f1b0e63b7498.mp4

</details>

## Changelog
:cl:
add: Adds Pixelshifting to the game!
/:cl: