### PR TITLE
Removes the chunky fingers check from the modular console.

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -138,10 +138,11 @@
 
 /obj/item/clothing/gloves/color/red/insulated
 	name = "insulated gloves"
-	desc = "These gloves provide protection against electric shock."
+	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
 	siemens_coefficient = 0
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 	resistance_flags = NONE
+	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/gloves/color/rainbow
 	name = "rainbow gloves"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -2,7 +2,7 @@
 	dying_key = DYE_REGISTRY_GLOVES
 
 /obj/item/clothing/gloves/color/yellow
-	desc = "These gloves provide protection against electric shock."
+	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
@@ -12,6 +12,7 @@
 	custom_price = PAYCHECK_CREW * 10
 	custom_premium_price = PAYCHECK_COMMAND * 6
 	cut_type = /obj/item/clothing/gloves/cut
+	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/gloves/color/yellow/heavy
 	name = "ceramic-lined insulated gloves"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -138,11 +138,10 @@
 
 /obj/item/clothing/gloves/color/red/insulated
 	name = "insulated gloves"
-	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
+	desc = "These gloves provide protection against electric shock."
 	siemens_coefficient = 0
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 	resistance_flags = NONE
-	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/gloves/color/rainbow
 	name = "rainbow gloves"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -2,7 +2,7 @@
 	dying_key = DYE_REGISTRY_GLOVES
 
 /obj/item/clothing/gloves/color/yellow
-	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
+	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
@@ -12,7 +12,6 @@
 	custom_price = PAYCHECK_CREW * 10
 	custom_premium_price = PAYCHECK_COMMAND * 6
 	cut_type = /obj/item/clothing/gloves/cut
-	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/gloves/color/yellow/heavy
 	name = "ceramic-lined insulated gloves"

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -105,6 +105,12 @@
 	if(.)
 		return
 
+	if(ishuman(usr) && !allow_chunky) //in /datum/computer_file/program/ui_act() too
+		var/mob/living/carbon/human/human_user = usr
+		if(human_user.check_chunky_fingers())
+			balloon_alert(human_user, "fingers are too big!")
+			return TRUE
+
 	if(active_program)
 		active_program.ui_act(action, params, ui, state)
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -105,12 +105,6 @@
 	if(.)
 		return
 
-	if(ishuman(usr) && !allow_chunky) //in /datum/computer_file/program/ui_act() too
-		var/mob/living/carbon/human/human_user = usr
-		if(human_user.check_chunky_fingers())
-			balloon_alert(human_user, "fingers are too big!")
-			return TRUE
-
 	if(active_program)
 		active_program.ui_act(action, params, ui, state)
 


### PR DESCRIPTION
## About The Pull Request
Removes the chunky finger check from the modular console (Basically engineering and others QOL when working with that machine)

Why? Because I hate having to take my gloves off when I'm playing engineering to interact with consoles or to preform other tasks. (Yes this is a salt PR)

## How Does This Help ***Gameplay***?
Engineers can now interact with consoles properly again while they are wearing insuls along with doing other things previously barred because of the chunky fingers trait on these gloves.

## How Does This Help ***Roleplay***?
Minimal impact on Roleplay.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/232338085-2591067d-4e06-472d-83cd-f95509b5d13f.mp4

</details>

## Changelog
:cl:
del: Removes the chunky fingers trait from Insuls. 
/:cl: