### PR TITLE
Changes the Weight class for stun/tele prods

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -632,7 +632,7 @@
 	worn_icon_state = null
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 3
 	throwforce = 5
 	cell_hit_cost = 2000


### PR DESCRIPTION
## About The Pull Request
Changes the weight class for stun and telepords to be normal instead of huge. I'm making this change so stun and tele prods can be hidden within backpacks again. Its stupid that batons are able to be put into a backpack but a stunprod isn't Imo so yeah hence the PR. (This is another salt PR)

## How Does This Help ***Gameplay***?
You can now hide your stunprods again in your backpack and be a sneaky tider instead of having a prod out at all times after you make one.

## How Does This Help ***Roleplay***?
It doesn't. Or it does probably because people can actually hide their stunprod instead of having it out for when they want to kidnap people for example.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/232801376-59a69241-9623-43ca-88d1-f5f4152de835.mp4

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Stunprods and tele prods fit in bags again.
/:cl: