### PR TITLE
Remove Atmos Tech and Prisoner Roles

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -103,36 +103,6 @@
 		access |= list(
 			ACCESS_MAINT_TUNNELS)
 
-/datum/id_trim/job/atmospheric_technician
-	assignment = "Atmospheric Technician"
-	trim_state = "trim_atmospherictechnician"
-	orbit_icon = "fan"
-	department_color = COLOR_ENGINEERING_ORANGE
-	subdepartment_color = COLOR_ENGINEERING_ORANGE
-	sechud_icon_state = SECHUD_ATMOSPHERIC_TECHNICIAN
-	minimal_access = list(
-		ACCESS_ATMOSPHERICS,
-		ACCESS_AUX_BASE,
-		ACCESS_CONSTRUCTION,
-		ACCESS_ENGINEERING,
-		ACCESS_EXTERNAL_AIRLOCKS,
-		ACCESS_MAINT_TUNNELS,
-		ACCESS_MECH_ENGINE,
-		ACCESS_MINERAL_STOREROOM,
-		)
-	extra_access = list(
-		ACCESS_ENGINE_EQUIP,
-		ACCESS_MINISAT,
-		ACCESS_TCOMMS,
-		ACCESS_TECH_STORAGE,
-		)
-	template_access = list(
-		ACCESS_CAPTAIN,
-		ACCESS_CHANGE_IDS,
-		ACCESS_CE,
-		)
-	job = /datum/job/atmospheric_technician
-
 /datum/id_trim/job/bartender
 	assignment = "Bartender"
 	trim_state = "trim_bartender"
@@ -1008,6 +978,7 @@
 	subdepartment_color = COLOR_ENGINEERING_ORANGE
 	sechud_icon_state = SECHUD_STATION_ENGINEER
 	minimal_access = list(
+		ACCESS_ATMOSPHERICS,
 		ACCESS_AUX_BASE,
 		ACCESS_CONSTRUCTION,
 		ACCESS_ENGINEERING,
@@ -1019,9 +990,6 @@
 		ACCESS_MINISAT,
 		ACCESS_TCOMMS,
 		ACCESS_TECH_STORAGE,
-		)
-	extra_access = list(
-		ACCESS_ATMOSPHERICS,
 		)
 	template_access = list(
 		ACCESS_CAPTAIN,

--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -43,11 +43,9 @@
 		/datum/job/lawyer,
 		// Cargo
 		/datum/job/cargo_technician,
-		// Science
-		/datum/job/roboticist,
 		// Engineering
 		/datum/job/station_engineer,
-		/datum/job/atmospheric_technician,
+		/datum/job/roboticist,
 	)
 
 /// This is only for assistants, because the syndies are a lot less likely to give a shit about what an assistant does, so they're a lot less likely to appear

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -53,11 +53,9 @@
 		/datum/job/curator,
 		// Cargo
 		/datum/job/cargo_technician,
-		// Science
-		/datum/job/roboticist,
 		// Engineering
 		/datum/job/station_engineer,
-		/datum/job/atmospheric_technician,
+		/datum/job/roboticist,
 	)
 
 /datum/traitor_objective/kidnapping/less_common

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -1,48 +1,8 @@
-/datum/job/atmospheric_technician
-	title = JOB_ATMOSPHERIC_TECHNICIAN
-	description = "Ensure the air is breathable on the station, fill oxygen tanks, fight fires, purify the air."
-	department_head = list(JOB_CHIEF_ENGINEER)
-	faction = FACTION_STATION
-	total_positions = 3
-	spawn_positions = 2
-	supervisors = SUPERVISOR_CE
-	selection_color = "#fff5cc"
-	exp_requirements = 60
-	exp_required_type = EXP_TYPE_CREW
-	exp_granted_type = EXP_TYPE_CREW
-
-	outfit = /datum/outfit/job/atmos
-	plasmaman_outfit = /datum/outfit/plasmaman/atmospherics
-
-	paycheck = PAYCHECK_CREW
-	paycheck_department = ACCOUNT_ENG
-
-	liver_traits = list(TRAIT_ENGINEER_METABOLISM)
-
-	display_order = JOB_DISPLAY_ORDER_ATMOSPHERIC_TECHNICIAN
-	bounty_types = CIV_JOB_ATMOS
-	departments_list = list(
-		/datum/job_department/engineering,
-		)
-
-	family_heirlooms = list(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
-
-	mail_goodies = list(
-		/obj/item/rpd_upgrade/unwrench = 30,
-		/obj/item/grenade/gas_crystal/crystal_foam = 10,
-		/obj/item/grenade/gas_crystal/proto_nitrate_crystal = 10,
-		/obj/item/grenade/gas_crystal/healium_crystal = 10,
-		/obj/item/grenade/gas_crystal/nitrous_oxide_crystal = 5,
-	)
-
-	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
-	rpg_title = "Aeromancer"
-
 /datum/outfit/job/atmos
 	name = "Atmospheric Technician"
-	jobtype = /datum/job/atmospheric_technician
+	jobtype = /datum/job/station_engineer
 
-	id_trim = /datum/id_trim/job/atmospheric_technician
+	id_trim = /datum/id_trim/job/station_engineer
 	uniform = /obj/item/clothing/under/rank/engineering/atmospheric_technician
 	belt = /obj/item/storage/belt/utility/atmostech
 	ears = /obj/item/radio/headset/headset_eng

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -20,7 +20,6 @@
 
 	family_heirlooms = list(/obj/item/pen/blue)
 	rpg_title = "Defeated Miniboss"
-	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 
 /datum/job/prisoner/New()
 	. = ..()

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -2,9 +2,6 @@
 	title = JOB_PRISONER
 	description = "Keep yourself occupied in permabrig."
 	department_head = list("The Security Team")
-	faction = FACTION_STATION
-	total_positions = 0
-	spawn_positions = 2
 	supervisors = "the security team"
 	selection_color = "#ffe1c3"
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -32,7 +32,8 @@
 		/obj/item/storage/box/lights/mixed = 20,
 		/obj/item/lightreplacer = 10,
 		/obj/item/holosign_creator/engineering = 8,
-		/obj/item/clothing/head/hardhat/red/upgraded = 1
+		/obj/item/clothing/head/hardhat/red/upgraded = 1,
+		/obj/item/rpd_upgrade/unwrench = 30,
 	)
 	rpg_title = "Crystallomancer"
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN


### PR DESCRIPTION
## About The Pull Request

Tin.

## How Does This Help ***Gameplay***?

Prisoner is a dead-end game, and we don't plan on supporting prison RP for the time being. It's just easier on everyone involved to have newer folk roll in as assistant instead.

Atmos tech is wholly redundant, and also has a terrible stigma between it and SE that I've witnessed over the years on other servers, plus, restricting access to a *singular room*, despite normal engis being able to access the SM, which arguably is just as atmos intensive seems backwards as all hell.

## How Does This Help ***Roleplay***?

A random-ass logistic station isn't holding prisoners for periods of time. It's a logistic station, with routine shipments. Prisoners won't be staying long.

Station engineers now have all-access to their own department, the way it should be. They also maintain all of the stations functions, the way it should be.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/234726222-72049b27-240b-4eb7-b1b6-6c3b6b597db4.png)
Gon

I forgot to take a screencap of the latejoin screen, but it too has no atmos or prisoner.
</details>

## Changelog

:cl:
del: Atmos tech. Their gear, aside from IDs still remain.
del: Prisoners, their IDs still remain.
balance: Station engineers now always have access to atmos.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
