### PR TITLE
[PORT] Space heaters heat up a wider area.

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -124,10 +124,10 @@
 	if(mode == HEATER_MODE_COOL)
 		delta_temperature *= -1
 	if(delta_temperature)
-		for (var/turf/open/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
-			var/datum/gas_mixture/turf_gasmix = turf.return_air()
-			turf_gasmix.temperature += delta_temperature
-			air_update_turf(FALSE, FALSE)
+				for (var/turf/open/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
+					var/datum/gas_mixture/turf_gasmix = turf.return_air()
+					turf_gasmix.temperature += delta_temperature
+					air_update_turf(FALSE, FALSE)
 	cell.use(required_energy / efficiency)
 
 /obj/machinery/space_heater/RefreshParts()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -124,11 +124,11 @@
 	if(mode == HEATER_MODE_COOL)
 		delta_temperature *= -1
 	if(delta_temperature)
-				for (var/turf/open/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
-					var/datum/gas_mixture/turf_gasmix = turf.return_air()
-					turf_gasmix.temperature += delta_temperature
-					air_update_turf(FALSE, FALSE)
-	cell.use(required_energy / efficiency)
+		for (var/turf/open/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
+			var/datum/gas_mixture/turf_gasmix = turf.return_air()
+			turf_gasmix.temperature += delta_temperature
+			air_update_turf(FALSE, FALSE)
+			cell.use(required_energy / efficiency)
 
 /obj/machinery/space_heater/RefreshParts()
 	. = ..()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -124,8 +124,10 @@
 	if(mode == HEATER_MODE_COOL)
 		delta_temperature *= -1
 	if(delta_temperature)
-		enviroment.temperature += delta_temperature
-		air_update_turf(FALSE, FALSE)
+		for (var/turf/open/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
+			var/datum/gas_mixture/turf_gasmix = turf.return_air()
+			turf_gasmix.temperature += delta_temperature
+			air_update_turf(FALSE, FALSE)
 	cell.use(required_energy / efficiency)
 
 /obj/machinery/space_heater/RefreshParts()


### PR DESCRIPTION
## About The Pull Request

- https://github.com/tgstation/tgstation/pull/71793

Ports the PR listed above and does as it says in the title. This is great for Engineering when they have to fix breached areas because the recovery of the stations atmos integrity will be much quicker.

## How Does This Help ***Gameplay***?
Engineering/Atmos qol change to make space heaters work quicker so damaged areas can be restored quicker. (Less having to stand around waiting for the air to be fixed yay)

## How Does This Help ***Roleplay***?
Minimal impact on roleplay. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

### Works pretty quick

https://user-images.githubusercontent.com/79924768/235352655-e5cf094d-0ba1-45b4-af63-1a6652424223.mp4

</details>

## Changelog
:cl:
qol: Space heaters work faster now by heating up a large area around them.
/:cl: