### PR TITLE
Gives shovels a much more appropriate hit sound

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -122,6 +122,7 @@
 	tool_behaviour = TOOL_SHOVEL
 	toolspeed = 1
 	usesound = 'sound/effects/shovel_dig.ogg'
+	hitsound = 'sound/items/trayhit1.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=50)
 	attack_verb_continuous = list("bashes", "bludgeons", "thrashes", "whacks")


### PR DESCRIPTION
## About The Pull Request
I was inspired to make this PR after beating someone to death with a shovel today so here we are. 
This PR changes the hit sound of shovels to no longer be a generic bash but instead it uses the same sound as chairs and stools. 
Why? Because its funny.

(Yes I'm dumb and I deleted my own repo so heres attempt number two of #167)

## How Does This Help ***Gameplay***?
Different sound when beating people with shovels, I see this new sound as an absolute improvement.

## How Does This Help ***Roleplay***?
Minimal impact on roleplay.

## Proof of Testing
<details>
<summary>Before</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/235367589-9050249b-ee7f-4e9c-add5-e8ee81dfd2e6.mp4

</details>

<details>
<summary>After</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/235367372-ad302dac-18e1-4864-a198-43176dc82b54.mp4

</details>

## Changelog
:cl:
soundadd: Changed the hit sound of shovels to be much more appropriate.
/:cl: