### PR TITLE
Fix Air Sensor Harddels

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -857,3 +857,12 @@ GLOBAL_LIST_EMPTY(colored_images)
 	our_gasmix.parse_string_immutable(atmos_datum.gas_string)
 	planetary["[level]"] = our_gasmix
 	z_level_to_gas_string["[level]"] = atmos_datum.gas_string
+
+/datum/controller/subsystem/air/proc/broadcast_air_sensor_destruction(frequency)
+	var/datum/signal/signal = new(list(
+		"sigtype" = "destroyed",
+		"tag" = id_tag,
+		"timestamp" = world.time,
+	))
+	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
+	INVOKE_ASYNC(connection, TYPE_PROC_REF(/datum/radio_frequency, post_signal), null, signal, RADIO_ATMOSIA)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -858,7 +858,7 @@ GLOBAL_LIST_EMPTY(colored_images)
 	planetary["[level]"] = our_gasmix
 	z_level_to_gas_string["[level]"] = atmos_datum.gas_string
 
-/datum/controller/subsystem/air/proc/broadcast_air_sensor_destruction(frequency)
+/datum/controller/subsystem/air/proc/broadcast_air_sensor_destruction(id_tag, frequency)
 	var/datum/signal/signal = new(list(
 		"sigtype" = "destroyed",
 		"tag" = id_tag,

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -858,7 +858,8 @@ GLOBAL_LIST_EMPTY(colored_images)
 	planetary["[level]"] = our_gasmix
 	z_level_to_gas_string["[level]"] = atmos_datum.gas_string
 
-/datum/controller/subsystem/air/proc/broadcast_air_sensor_destruction(id_tag, frequency)
+/// Helper proc to remove an atmos-monitor'd component from the network. Done here to avoid harddels from GC/async SSradio overlap.
+/datum/controller/subsystem/air/proc/broadcast_destruction(id_tag, frequency)
 	var/datum/signal/signal = new(list(
 		"sigtype" = "destroyed",
 		"tag" = id_tag,

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -21,19 +21,10 @@
 	return ..()
 
 /obj/machinery/air_sensor/Destroy()
-	broadcast_destruction(src.frequency)
+	SSair.broadcast_air_sensor_destruction(src.frequency)
 	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()
-
-/obj/machinery/air_sensor/proc/broadcast_destruction(frequency)
-	var/datum/signal/signal = new(list(
-		"sigtype" = "destroyed",
-		"tag" = id_tag,
-		"timestamp" = world.time,
-	))
-	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
-	INVOKE_ASYNC(connection, TYPE_PROC_REF(/datum/radio_frequency, post_signal), null, signal, RADIO_ATMOSIA)
 
 /obj/machinery/air_sensor/update_icon_state()
 	icon_state = "gsensor[on]"

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -21,7 +21,7 @@
 	return ..()
 
 /obj/machinery/air_sensor/Destroy()
-	INVOKE_ASYNC(src, PROC_REF(broadcast_destruction), src.frequency)
+	broadcast_destruction(frequency)
 	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -21,7 +21,7 @@
 	return ..()
 
 /obj/machinery/air_sensor/Destroy()
-	broadcast_destruction(frequency)
+	broadcast_destruction(src.frequency)
 	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()
@@ -33,7 +33,7 @@
 		"timestamp" = world.time,
 	))
 	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
-	connection.post_signal(null, signal, filter = RADIO_ATMOSIA)
+	INVOKE_ASYNC(connection, TYPE_PROC_REF(/datum/radio_frequency, post_signal), null, signal, RADIO_ATMOSIA)
 
 /obj/machinery/air_sensor/update_icon_state()
 	icon_state = "gsensor[on]"

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -21,7 +21,7 @@
 	return ..()
 
 /obj/machinery/air_sensor/Destroy()
-	SSair.broadcast_air_sensor_destruction(src.frequency)
+	SSair.broadcast_air_sensor_destruction(id_tag, frequency)
 	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -21,7 +21,7 @@
 	return ..()
 
 /obj/machinery/air_sensor/Destroy()
-	SSair.broadcast_air_sensor_destruction(id_tag, frequency)
+	SSair.broadcast_destruction(id_tag, frequency)
 	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()

--- a/code/game/machinery/computer/atmos_computers/inlets.dm
+++ b/code/game/machinery/computer/atmos_computers/inlets.dm
@@ -10,7 +10,7 @@
 	id_tag = chamber_id + "_in"
 	radio_connection = SSradio.add_object(src, frequency, RADIO_ATMOSIA)
 	return ..()
-	
+
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/atmos_init()
 	. = ..()
 	broadcast_status()
@@ -21,7 +21,7 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/on_deconstruction()
 	. = ..()
-	INVOKE_ASYNC(src, PROC_REF(broadcast_destruction), src.frequency)
+	SSair.broadcast_destruction(id_tag, frequency)
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ui_act(action, params)
 	. = ..()

--- a/code/game/machinery/computer/atmos_computers/inlets.dm
+++ b/code/game/machinery/computer/atmos_computers/inlets.dm
@@ -42,15 +42,6 @@
 	))
 	radio_connection.post_signal(src, signal)
 
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/proc/broadcast_destruction(frequency)
-	var/datum/signal/signal = new(list(
-		"sigtype" = "destroyed",
-		"tag" = id_tag,
-		"timestamp" = world.time,
-	))
-	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
-	connection.post_signal(null, signal, filter = RADIO_ATMOSIA)
-
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/receive_signal(datum/signal/signal)
 	if(!signal.data["tag"] || (signal.data["tag"] != id_tag) || (signal.data["sigtype"]!="command"))
 		return

--- a/code/game/machinery/computer/atmos_computers/meters.dm
+++ b/code/game/machinery/computer/atmos_computers/meters.dm
@@ -16,7 +16,7 @@
 
 /obj/machinery/meter/monitored/on_deconstruction()
 	. = ..()
-	INVOKE_ASYNC(src, PROC_REF(broadcast_destruction), src.frequency)
+	SSair.broadcast_destruction(id_tag, frequency)
 
 /obj/machinery/meter/monitored/proc/broadcast_destruction(frequency)
 	var/datum/signal/signal = new(list(

--- a/code/game/machinery/computer/atmos_computers/meters.dm
+++ b/code/game/machinery/computer/atmos_computers/meters.dm
@@ -18,15 +18,6 @@
 	. = ..()
 	SSair.broadcast_destruction(id_tag, frequency)
 
-/obj/machinery/meter/monitored/proc/broadcast_destruction(frequency)
-	var/datum/signal/signal = new(list(
-		"sigtype" = "destroyed",
-		"tag" = id_tag,
-		"timestamp" = world.time,
-	))
-	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
-	connection.post_signal(null, signal, filter = RADIO_ATMOSIA)
-
 /obj/machinery/meter/monitored/process_atmos()
 	. = ..()
 	if(!radio_connection)

--- a/code/game/machinery/computer/atmos_computers/outlets.dm
+++ b/code/game/machinery/computer/atmos_computers/outlets.dm
@@ -23,15 +23,6 @@
 	if(new_frequency)
 		radio_connection = SSradio.add_object(src, new_frequency, RADIO_ATMOSIA)
 
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/proc/broadcast_destruction(frequency)
-	var/datum/signal/signal = new(list(
-		"sigtype" = "destroyed",
-		"tag" = id_tag,
-		"timestamp" = world.time,
-	))
-	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
-	connection.post_signal(null, signal, filter = RADIO_ATMOSIA)
-
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output
 	name = "plasma tank output inlet"
 	chamber_id = ATMOS_GAS_MONITOR_PLAS

--- a/code/game/machinery/computer/atmos_computers/outlets.dm
+++ b/code/game/machinery/computer/atmos_computers/outlets.dm
@@ -15,7 +15,7 @@
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/on_deconstruction()
 	. = ..()
-	INVOKE_ASYNC(src, PROC_REF(broadcast_destruction), src.frequency)
+	SSair.broadcast_destruction(id_tag, frequency)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
@@ -140,28 +140,19 @@
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/Destroy()
-	INVOKE_ASYNC(src, PROC_REF(broadcast_destruction), src.frequency)
+	SSair.broadcast_destruction(id_tag, frequency)
 	SSradio.remove_object(src, frequency)
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/on_deconstruction()
 	. = ..()
-	INVOKE_ASYNC(src, PROC_REF(broadcast_destruction), src.frequency)
+	SSair.broadcast_destruction(id_tag, frequency)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)
 	frequency = new_frequency
 	if(new_frequency)
 		radio_connection = SSradio.add_object(src, new_frequency, RADIO_ATMOSIA)
-
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/proc/broadcast_destruction(frequency)
-	var/datum/signal/signal = new(list(
-		"sigtype" = "destroyed",
-		"tag" = id_tag,
-		"timestamp" = world.time,
-	))
-	var/datum/radio_frequency/connection = SSradio.return_frequency(frequency)
-	connection.post_signal(null, signal, filter = RADIO_ATMOSIA)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output
 	name = "air mix tank output inlet"


### PR DESCRIPTION
## About The Pull Request

Github can run more tests faster than I can, so you guys get to witness my mostly blind stumbling as I try to figure out just what the hell is breaking air alarm deletions.

Anyways, the reason for the harddels:

Async calls to SSradio were running slower than the GC at times in CI, so it was causing issues.
So I moved all the async calls to be handled by SSair instead, so references to atoms in the create and delete tests are replaced by SSair instead. 
Also saves a lot of copypaste code.

## Proof of Testing

See if CI is consistently passing.

## Changelog

No CL, CI-bearing change.