### PR TITLE
[QOL] Adds the crew manifest as a default program to all PDA's

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -35,6 +35,7 @@
 	var/static/list/datum/computer_file/pda_programs = list(
 		/datum/computer_file/program/messenger,
 		/datum/computer_file/program/notepad,
+		/datum/computer_file/program/crew_manifest,
 	)
 	///List of items that can be stored in a PDA
 	var/static/list/contained_item = list(


### PR DESCRIPTION
## About The Pull Request
Does as it says in the title, nothing else really.

I was motivated to make this PR because I'm used to being able to check the manifest whenever I want as normal crew and TG deciding to restrict it to command and sec only is a bit stupid to me.

## How Does This Help ***Gameplay***?
Normal crew can now easily check if someone is on the manifest or not and you can see if your friends are on station or not.

## How Does This Help ***Roleplay***?
Want to see if who is on station but you're not a member of sec or command? Now you can! (Will allow for people to see if their friends are around alot easier while they are in the round) 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/79924768/235910540-413614a2-86e5-4e53-9323-c80f7c7609b1.png)

![image](https://user-images.githubusercontent.com/79924768/235909461-a572cb0e-829f-42f5-a18c-f032be4a4155.png)

</details>

## Changelog
:cl:
qol: Adds the crew manifest as a default a program to all PDA's. 
/:cl: