### PR TITLE
[Port] Pixel perfect pointing (With rotated arrows)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -80,7 +80,7 @@
 
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))
 		if(LAZYACCESS(modifiers, MIDDLE_CLICK))
-			ShiftMiddleClickOn(A)
+			ShiftMiddleClickOn(A, params)
 			return
 		if(LAZYACCESS(modifiers, CTRL_CLICK))
 			CtrlShiftClickOn(A)
@@ -456,8 +456,8 @@
 	A.CtrlShiftClick(src)
 	return
 
-/mob/proc/ShiftMiddleClickOn(atom/A)
-	src.pointed(A)
+/mob/proc/ShiftMiddleClickOn(atom/A, params)
+	pointed(A, params)
 	return
 
 /atom/proc/CtrlShiftClick(mob/user)


### PR DESCRIPTION
## About The Pull Request
Port of:
- https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/324

This changes pointing at things so its down to the pixel you clicked on and no longer the object. See the video in testing proof for a demonstration.

## How Does This Help ***Gameplay***?
More precise pointing is always nice.

## How Does This Help ***Roleplay***?
Minimal impact on roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://user-images.githubusercontent.com/79924768/236691424-4c9acdd5-caf5-4747-afc5-c51fcf03e26a.mp4

</details>

## Changelog
:cl:
code: Pointing is now precise to the pixel and no longer works with objects, pointing arrows are now also rotated depending on what you pointed at.
/:cl: