### PR TITLE
funny double text removal on supply pod beacons

### DIFF
--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -1,7 +1,6 @@
 /obj/item/supplypod_beacon
 	name = "Supply Pod Beacon"
 	desc = "A device that can be linked to an Express Supply Console for precision supply pod deliveries."
-	desc_controls = "Alt-click to remove link."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "supplypod_beacon"
 	inhand_icon_state = "radio"


### PR DESCRIPTION
## About The Pull Request
Does what it says in the title and its literally a 1 line change so what else do you want me to say lol

## How Does This Help ***Gameplay***?
Minimal impact on gameplay but nice to have considering cargo is gonna be more important for us.

## How Does This Help ***Roleplay***?
Minimal impact on roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

### Before
![image](https://user-images.githubusercontent.com/79924768/236908682-043dcb46-1073-4105-aa2c-24a6331a4a49.png)

### After
![image](https://user-images.githubusercontent.com/79924768/236908081-c741fc56-9027-4544-aa96-625794068bc9.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
del: Removed double text about controls on supply pod beacons.
/:cl: