### PR TITLE
Make Suit Storage Unit Use Industrial Sprites

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -1,10 +1,10 @@
 // SUIT STORAGE UNIT /////////////////
 /obj/machinery/suit_storage_unit
-	name = "suit storage unit"
+	name = "industrial suit storage unit"
 	desc = "An industrial unit made to hold and decontaminate irradiated equipment. It comes with a built-in UV cauterization mechanism. A small warning label advises that organic matter should not be placed into the unit."
 	icon = 'icons/obj/machines/suit_storage.dmi'
-	icon_state = "classic"
-	base_icon_state = "classic"
+	icon_state = "industrial"
+	base_icon_state = "industrial"
 	power_channel = AREA_USAGE_EQUIP
 	density = TRUE
 	obj_flags = NO_BUILD // Becomes undense when the unit is open


### PR DESCRIPTION
## About The Pull Request

The industrial sprites fit our sprite style so much better. I also hate how the round ones look.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/236941537-edd073bd-0371-41d9-a2a1-14e37c2bd79e.png)

</details>

## Changelog


:cl:
imageadd: Suit storage units now exclusively look industrial!
/:cl:

