### PR TITLE
Adds Wired and Wired+Anchored Machine Frame Subtypes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -312,3 +312,10 @@
 			var/obj/item/I = X
 			I.forceMove(loc)
 	..()
+
+/obj/structure/frame/machine/wired
+	state = 2
+	icon_state = "box_1"
+
+/obj/structure/frame/machine/wired/anchored
+	anchored = TRUE


### PR DESCRIPTION
## About The Pull Request

I hate varediting.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://user-images.githubusercontent.com/106692773/236943496-ea90a98b-392e-4c1f-8a87-49f56260aa81.png)
![image](https://user-images.githubusercontent.com/106692773/236944160-e59cf7f9-a2bf-4fcd-97ba-7d85880736a9.png)
![image](https://user-images.githubusercontent.com/106692773/236944411-6fd78f1d-de91-48fd-a4c2-a13629f6638f.png)
Wrenched and unwrenched
![image](https://user-images.githubusercontent.com/106692773/236944296-9f2ed940-739d-4e9f-9eae-6b356ed01266.png)
Wires work.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Added a couple of machine frame subtypes for being wired and optionally anchored.
/:cl:
