### PR TITLE
Shift Fax Machines to Look Correct On Tables

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -9,6 +9,7 @@
 	pass_flags = PASSTABLE
 	circuit = /obj/item/circuitboard/machine/fax
 	interaction_sound = SFX_KEYBOARD
+	pixel_y = 6 // Makes these look right on tables
 	/// The unique ID by which the fax will build a list of existing faxes.
 	var/fax_id
 	/// The name of the fax displayed in the list. Not necessarily unique to some EMAG jokes.


### PR DESCRIPTION
## About The Pull Request

Shifts fax machines up by 6 pixels, making them look like how they should on tables: Actually on the fucking things.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

LOOK, IT'S ON THE FUCKING TABLE
![image](https://user-images.githubusercontent.com/106692773/236946195-1baed887-0a5d-49d1-98e3-cdfdd358b494.png)

THE TAAAAAAABLE
![image](https://user-images.githubusercontent.com/106692773/236946295-d994ef8f-694f-461d-8d9a-3090a289d1a2.png)

![image](https://user-images.githubusercontent.com/106692773/236946404-8caf41ae-c230-4ab1-ade6-1f0bfaf6e1d6.png)

</details>

## Changelog

:cl:
qol: Fax machines actually sit on tables.
/:cl:
