### PR TITLE
Anchors mapping helpers so they don't get put inside crates

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -91,6 +91,7 @@
 /obj/effect/mapping_helpers
 	icon = 'icons/effects/mapping_helpers.dmi'
 	icon_state = ""
+	anchored = TRUE
 	var/late = FALSE
 
 /obj/effect/mapping_helpers/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
Saw this in a TG PR, free futureproof linters fix and mapping foolproofing and I swear no mapping helpers are scooting around anyways so it's fine.
