### PR TITLE
Makes Ballistic Projectiles Significantly Damage Walls

### DIFF
--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -51,6 +51,32 @@
 	/// Typecache of all objects that we seek out to apply a neighbor stripe overlay
 	var/static/list/neighbor_typecache
 
+	// Vars for bullet hitting wall interactions
+	max_integrity = 100 // Most common ballistics deal 20-30 damage a shot.
+	damage_deflection = 5
+
+/turf/closed/wall/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
+	if(damage_type != BRUTE)
+		return 0 // We don't take any damage from non-brute sources.
+
+	if(damage_amount <= damage_deflection)
+		return 0 // Don't take damage from sources too weak to hurt.
+
+	//Note: Walls are weaker the higher the hardness. Don't ask me why.
+
+	if(hardness > 70) // Some mineral walls are weaker than this.
+		damage_amount *= 3
+	else if(hardness > 10) // 10 is the hardness of r-walls.
+		damage_amount *= 2
+
+	. = damage_amount
+
+	atom_integrity = max(0, get_integrity() - damage_amount)
+
+	if(get_integrity() <= 0)
+		dismantle_wall()
+		return damage_amount
+
 /turf/closed/wall/update_greyscale()
 	greyscale_colors = get_wall_color()
 	return ..()
@@ -88,6 +114,9 @@
 	set_materials(plating_material, reinf_material)
 	if(is_station_level(z))
 		GLOB.station_turfs += src
+
+	// Yes, this is required, because we don't actually follow the normal integrity implementation in walls.
+	atom_integrity = max_integrity
 
 /turf/closed/wall/Destroy()
 	if(is_station_level(z))
@@ -366,6 +395,7 @@
 		if(W.use_tool(src, user, 0, volume=100))
 			if(iswallturf(src) && LAZYLEN(dent_decals))
 				to_chat(user, span_notice("You fix some dents on the wall."))
+				update_integrity(max_integrity)
 				cut_overlay(dent_decals)
 				dent_decals.Cut()
 			return TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -267,7 +267,8 @@
 		if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)
 
-		W.add_dent(WALL_DENT_SHOT, hitx, hity)
+		if(damage_type == BRUTE && W.take_damage(damage, damage_type, attack_dir = REVERSE_DIR(dir), armour_penetration = armour_penetration))
+			W.add_dent(WALL_DENT_SHOT, hitx, hity)
 
 		return BULLET_ACT_HIT
 


### PR DESCRIPTION
## About The Pull Request

Makes it so most ballistic firearms take ~4 shots to break a normal wall, and ~8 to murder Rwalls. Note that it leaves a girder behind, so it still isn't a trump card to speedily breach and enter a room.

Walls have health under the hood now, though it doesn't follow the normal system, due to some *deep* level logic that I really don't want to touch.

Walls have 100 health base.

Weak walls (wood, mostly) take triple damage.
Normal walls (iron, titanium) take double damage.
RWalls (plasteel, plastitanium) take normal damage.

Normal and weak walls ignore projectiles that deal 5 damage or less.
Rwalls ignore projectiles with 10 damage or less.

This does mean you can still "safely" use beanbag and dart shots inside the station.

Bullet hole decals are now no longer cosmetic, and indicate that the wall has been shot with a projectile that damaged it.

## How Does This Help ***Gameplay***?

These walls aren't bulletproof. Also let's make it even more clear that ballistic firearms are a last resort.

## Proof of Testing

Locally tested, and it works as intended. Screens incoming.

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

</details>

## Changelog

:cl:
balance: Walls are no longer invincible to ballistic firearms. This is a space station, so don't go firing that gun without reason!
/:cl:
