### PR TITLE
[FUCK] Fixes pathfinders department not loading properly during init (This is a fix that only applies to me for some reason, so grammer formatting lol) 

### DIFF
--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -1494,11 +1494,8 @@
 /area/station/pathfinders/dock
 	name = "\improper Pathfinders Dock"
 
-
 /area/station/pathfinders/locker_room
 	name = "\improper Pathfinders Locker room"
 
 /area/station/pathfinders/lead_office
 	name = "\improper Lead Pathfinder Office"
-
-


### PR DESCRIPTION
## About The Pull Request
Does what it says in the title. I caused this bug myself and Idk how it didn't pop up during the playtest but here we are. #189 caused this. _Woops_

### The issue this fixes
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/e038b0c9-c528-45dc-8deb-9af6972d7dfe)

## How Does This Help ***Gameplay***?
Pathfinders can play the game again.

## How Does This Help ***Roleplay***?
Pathfinders are part of the station again.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

### We are so back

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/d046143f-4d70-4cfb-b7a6-245e2192d028)

</details>

## Changelog
:cl:
fix: Fixed a mistake that caused the entire pathfinders department to get deleted.
/:cl: