### PR TITLE
Moved Erp prefs down to the bottom of the list in content selection

### DIFF
--- a/code/modules/client/preferences/content.dm
+++ b/code/modules/client/preferences/content.dm
@@ -25,67 +25,6 @@
 		CRASH("No default value set for [type]!")
 	return default_value
 
-/datum/preference/choiced/content/erp_status
-	savefile_key = "erp_status"
-	default_value = "No"
-
-/datum/preference/choiced/content/erp_status/init_possible_values()
-	return list(
-		"No",
-		"Check OOC Notes",
-		"Yes",
-		"Yes - Dom",
-		"Yes - Dom Lean",
-		"Yes - Switch",
-		"Yes - Sub Lean",
-		"Yes - Sub",
-	)
-
-/datum/preference/choiced/content/erp_orientation
-	savefile_key = "erp_orientation"
-	default_value = "Asexual"
-
-/datum/preference/choiced/content/erp_orientation/init_possible_values()
-	return list(
-		"Asexual",
-		"Female",
-		"Feminine",
-		"Pansexual - Female Lean",
-		"Pansexual - Feminine Lean",
-		"Pansexual",
-		"Pansexual - Masculine Lean",
-		"Pansexual - Male Lean",
-		"Masculine",
-		"Male",
-	)
-
-/datum/preference/choiced/content/erp_position
-	savefile_key = "erp_position"
-	default_value = "None"
-
-/datum/preference/choiced/content/erp_position/init_possible_values()
-	return list(
-		"Top",
-		"Top Lean",
-		"Switch",
-		"Bottom Lean",
-		"Bottom",
-		"None",
-	)
-
-/datum/preference/choiced/content/erp_non_con
-	savefile_key = "erp_non_con"
-	default_value = "No"
-
-/datum/preference/choiced/content/erp_non_con/init_possible_values()
-	return list(
-		"No",
-		"Check OOC Notes",
-		"Yes - Dom",
-		"Yes",
-		"Yes - Sub",
-	)
-
 /datum/preference/choiced/content/death
 	savefile_key = "content_death"
 	default_value = "Unset"
@@ -174,4 +113,65 @@
 		"Prefer Not",
 		"No",
 		"Unset",
+	)
+
+/datum/preference/choiced/content/erp_status
+	savefile_key = "erp_status"
+	default_value = "No"
+
+/datum/preference/choiced/content/erp_status/init_possible_values()
+	return list(
+		"No",
+		"Check OOC Notes",
+		"Yes",
+		"Yes - Dom",
+		"Yes - Dom Lean",
+		"Yes - Switch",
+		"Yes - Sub Lean",
+		"Yes - Sub",
+	)
+
+/datum/preference/choiced/content/erp_orientation
+	savefile_key = "erp_orientation"
+	default_value = "Asexual"
+
+/datum/preference/choiced/content/erp_orientation/init_possible_values()
+	return list(
+		"Asexual",
+		"Female",
+		"Feminine",
+		"Pansexual - Female Lean",
+		"Pansexual - Feminine Lean",
+		"Pansexual",
+		"Pansexual - Masculine Lean",
+		"Pansexual - Male Lean",
+		"Masculine",
+		"Male",
+	)
+
+/datum/preference/choiced/content/erp_position
+	savefile_key = "erp_position"
+	default_value = "None"
+
+/datum/preference/choiced/content/erp_position/init_possible_values()
+	return list(
+		"Top",
+		"Top Lean",
+		"Switch",
+		"Bottom Lean",
+		"Bottom",
+		"None",
+	)
+
+/datum/preference/choiced/content/erp_non_con
+	savefile_key = "erp_non_con"
+	default_value = "No"
+
+/datum/preference/choiced/content/erp_non_con/init_possible_values()
+	return list(
+		"No",
+		"Check OOC Notes",
+		"Yes - Dom",
+		"Yes",
+		"Yes - Sub",
 	)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/content.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/content.tsx
@@ -7,31 +7,6 @@ export const be_victim: Feature<boolean> = {
   component: CheckboxInput,
 };
 
-export const erp_status: Feature<string> = {
-  name: 'ERP Status',
-  description: 'Whether you want to ERP, and the dom/sub role you prefer.',
-  component: FeatureDropdownInput,
-};
-
-export const erp_orientation: Feature<string> = {
-  name: 'ERP Status',
-  description: 'Whether you want to ERP, and the dom/sub role you prefer.',
-  component: FeatureDropdownInput,
-};
-
-export const erp_position: Feature<string> = {
-  name: 'ERP Position',
-  description: 'What position you enjoy taking during ERP.',
-  component: FeatureDropdownInput,
-};
-
-export const erp_non_con: Feature<string> = {
-  name: 'ERP Non-Con Preference',
-  description:
-    "Whether you want to partake in non consensual ERP. Be ware that this should be done in private locations, for other player's sakes.",
-  component: FeatureDropdownInput,
-};
-
 export const content_brainwashing: Feature<string> = {
   name: 'Brainwashing',
   description: 'Whether you want to be, or are fine with being brainwashed.',
@@ -74,5 +49,30 @@ export const content_round_removal: Feature<string> = {
   name: 'Round Removal',
   description:
     'Whether you want to be, or are fine with being round removed by players. Do note that there are of course, certain situations which can result in round removals due to game mechanics, which cannot be helped in certain situations.',
+  component: FeatureDropdownInput,
+};
+
+export const erp_status: Feature<string> = {
+  name: 'ERP Status',
+  description: 'Whether you want to ERP, and the dom/sub role you prefer.',
+  component: FeatureDropdownInput,
+};
+
+export const erp_orientation: Feature<string> = {
+  name: 'ERP Status',
+  description: 'Whether you want to ERP, and the dom/sub role you prefer.',
+  component: FeatureDropdownInput,
+};
+
+export const erp_position: Feature<string> = {
+  name: 'ERP Position',
+  description: 'What position you enjoy taking during ERP.',
+  component: FeatureDropdownInput,
+};
+
+export const erp_non_con: Feature<string> = {
+  name: 'ERP Non-Con Preference',
+  description:
+    "Whether you want to partake in non consensual ERP. Be ware that this should be done in private locations, for other player's sakes.",
   component: FeatureDropdownInput,
 };


### PR DESCRIPTION
## About The Pull Request
Moved Erp prefs down to the bottom of the content prefs list in an effort to make ERP less of a focus when people select their prefs. Something something this isn't an ERP server.

## How Does This Help ***Gameplay***?
Minimal impact on gameplay.

## How Does This Help ***Roleplay***?
Minimal impact on roleplay

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/9a741931-846a-4709-aebc-340787c3b48f)

</details>

## Changelog
:cl:
code: Moved Erp prefs to the bottom of the content prefs list.
/:cl: