### PR TITLE
[Port] Exclude statbrowser from seconds topic limiter

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -38,9 +38,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(!usr || usr != mob) //stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
 
-#ifndef TESTING	
+#ifndef TESTING
 	if (lowertext(hsrc_command) == "_debug") //disable the integrated byond vv in the client side debugging tools since it doesn't respect vv read protections
-		return 
+		return
 #endif
 
 	// asset_cache
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return
 
 	var/stl = CONFIG_GET(number/second_topic_limit)
-	if (!holder && stl)
+	if (!holder && stl && href_list["window_id"] != "statbrowser")
 		var/second = round(world.time, 10)
 		if (!topiclimiter)
 			topiclimiter = new(LIMITER_SIZE)


### PR DESCRIPTION
## About The Pull Request
Port of: 
- https://github.com/tgstation/tgstation/pull/70386

I saw a fix for this getting merged on DD and they grabbed it from TG so here we are. 

## How Does This Help ***Gameplay***?
Minimal impact on gameplay

## How Does This Help ***Roleplay***?
Minimal impact on gameplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/3569578a-fb50-48c3-a4c8-3442a7907cea)

The "your previous action was ignored" message also appears to be gone when you reconnect now.

</details>

## Changelog
:cl:
fix: You will no longer get the "your previous action was ignored" message when you join the server.
/:cl: