### PR TITLE
[PORT] Adds a message to the autokick for when people send too many inputs.

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -23,6 +23,7 @@
 			keysend_tripped = TRUE
 			next_keysend_trip_reset = world.time + (2 SECONDS)
 		else
+			to_chat(src, span_userdanger("Flooding keysends! This could have been caused by lag, or due to a plugged-in game controller. You have been disconnected from the server automatically."))
 			log_admin("Client [ckey] was just autokicked for flooding keysends; likely abuse but potentially lagspike.")
 			message_admins("Client [ckey] was just autokicked for flooding keysends; likely abuse but potentially lagspike.")
 			qdel(src)


### PR DESCRIPTION
## About The Pull Request
This is a port of:
- https://github.com/tgstation/tgstation/pull/72083

See the TG PR for more details please.

## How Does This Help ***Gameplay***?
You'll know when you get kicked now instead of it looking like just another random byond crash.

## How Does This Help ***Roleplay***?
Minimal impact on roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/b6bac7af-a234-4cad-9f20-8d24a5f4ad03)

I dont know how to get the game to kick me for sending too many inputs effectively but trust me it works. Its a small change anyways so it should be fine lol

</details>

## Changelog
:cl:
add: Adds a kick message when the game kicks people for sending too many inputs.
/:cl: