### PR TITLE
Fixed a tiny mapping error on Kilo

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -76982,16 +76982,6 @@
 /obj/structure/sign/warning/deathsposal,
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
-"wuE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "wuI" = (
 /obj/structure/sign/poster/contraband/missing_gloves,
 /turf/closed/wall/rust,
@@ -118195,7 +118185,7 @@ qdk
 bBF
 dpJ
 hLS
-wuE
+tWg
 wjI
 rLs
 lFt

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -11630,9 +11630,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "dEc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -11641,6 +11638,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -21484,9 +21484,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/exam_room)
 "gsu" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/button/door/directional/north{
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
@@ -21500,6 +21497,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
@@ -28019,9 +28019,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "ijF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -28029,6 +28026,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,


### PR DESCRIPTION
## About The Pull Request

Fixes this because it looks awful:
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/a72ec323-d372-492b-a2b6-d41cb4e8b869)

## How Does This Help ***Gameplay***?
Mapping errors bad! Good looking maps good!

## How Does This Help ***Roleplay***?
Minimal impact on roleplay, unless this mapping error really breaks your immersion.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/7248ec1a-b275-4e83-a5f6-043c92832804)

</details>

## Changelog
:cl:
fix: Fixed some decals on Kilo looking really bad.
/:cl: