### PR TITLE
[PORT] Fixes floating point inaccuracies in numeric preferences

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -9,7 +9,7 @@
 /proc/sanitize_float(number, min=0, max=1, accuracy=1, default=0)
 	if(isnum(number))
 		number = round(number, accuracy)
-		if(min <= number && number <= max)
+		if(round(min, accuracy) <= number && number <= round(max, accuracy))
 			return number
 	return default
 

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -576,8 +576,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	return rand(minimum, maximum)
 
 /datum/preference/numeric/is_valid(value)
-	return isnum(value) && value >= minimum && value <= maximum
-
+	return isnum(value) && value >= round(minimum, step) && value <= round(maximum, step)
 /datum/preference/numeric/compile_constant_data()
 	return list(
 		"minimum" = minimum,


### PR DESCRIPTION
## About The Pull Request
This PR is a port of:
- https://github.com/tgstation/tgstation/pull/74384

This is out of my depth and idk how to reproduce it but we wanted this fix so here we are. 
For more details please look at the original PR.

## How Does This Help ***Gameplay***?
Minimal impact on gameplay. 

## How Does This Help ***Roleplay***?
Minimal impact on roleplay. 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/89d28f9a-c127-407f-ad07-42610177288b)

</details>

## Changelog
:cl:
fix: fixes floating point inaccuracies in numeric prefs
/:cl: