### PR TITLE
[PORT] Grilles will no longer shock you when they're placed on a floor tile with a wire below it. 

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -247,6 +247,8 @@
 	if(!in_range(src, user))//To prevent TK and mech users from getting shocked
 		return FALSE
 	var/turf/T = get_turf(src)
+	if(T.overfloor_placed)//cant be a floor in the way!
+		return FALSE
 	var/obj/structure/cable/C = T.get_cable_node()
 	if(C)
 		if(electrocute_mob(user, C, src, 1, TRUE))
@@ -270,6 +272,8 @@
 			var/obj/O = AM
 			if(O.throwforce != 0)//don't want to let people spam tesla bolts, this way it will break after time
 				var/turf/T = get_turf(src)
+				if(T.overfloor_placed)
+					return FALSE
 				var/obj/structure/cable/C = T.get_cable_node()
 				if(C)
 					playsound(src, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)


### PR DESCRIPTION
## About The Pull Request
This is a port of:
- https://github.com/tgstation/tgstation/pull/75703

This will stop grilles from shocking people if one is placed onto a floor tile with a powered cable below it. 

## How Does This Help ***Gameplay***?
No more weird funny shocking grilles when it shouldn't be possible. 😢 

## How Does This Help ***Roleplay***?
Minimal impact on roleplay unless this ruined your immersion.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/e2967054-2239-436e-86fa-0e0383c87e39

</details>

## Changelog
:cl:
fix: Stops grilles from electrocuting or tesla-ing when there's a floor between the grille and the cable.
/:cl:

