### PR TITLE
Removes Roundstart MODsuits and replaces them with Hardsuits on Kilostation.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3387,7 +3387,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "baC" = (
-/obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -3398,6 +3397,7 @@
 	name = "atmospherics camera";
 	network = list("ss13","engine")
 	},
+/obj/machinery/suit_storage_unit/hardsuit/atmospherics,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "baE" = (
@@ -3469,7 +3469,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/bomb)
 "bcQ" = (
-/obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -3477,6 +3476,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit/hardsuit/atmospherics,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bcY" = (
@@ -22858,7 +22858,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "gMC" = (
-/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -22868,6 +22867,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/suit_storage_unit/hardsuit/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gME" = (
@@ -23536,7 +23536,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/suit_storage_unit/medical,
+/obj/machinery/suit_storage_unit/hardsuit/medical,
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
 "gVi" = (
@@ -27257,7 +27257,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/suit_storage_unit/security,
+/obj/machinery/suit_storage_unit/hardsuit/security,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hZp" = (
@@ -37129,7 +37129,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/security,
+/obj/machinery/suit_storage_unit/hardsuit/security,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kSp" = (
@@ -45668,7 +45668,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "nvA" = (
-/obj/machinery/suit_storage_unit/hos,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -45680,6 +45679,7 @@
 	pixel_x = 36;
 	pixel_y = 28
 	},
+/obj/machinery/suit_storage_unit/hardsuit/hos,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hos)
 "nvE" = (
@@ -51727,12 +51727,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "poK" = (
-/obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/suit_storage_unit/hardsuit/ce,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "poU" = (
@@ -63635,9 +63635,9 @@
 /area/station/maintenance/port/aft)
 "sKm" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light/directional/west,
+/obj/machinery/suit_storage_unit/hardsuit/cmo,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "sKu" = (
@@ -69693,7 +69693,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/suit_storage_unit/engine,
+/obj/machinery/suit_storage_unit/hardsuit/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "usp" = (
@@ -80836,9 +80836,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/engine,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/suit_storage_unit/hardsuit/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xCy" = (

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -126,6 +126,50 @@
 	helmet_type = /obj/item/clothing/head/radiation
 	storage_type = /obj/item/geiger_counter
 
+/// Hardsuit suit storage units
+
+/obj/machinery/suit_storage_unit/hardsuit/engineering
+	suit_type = /obj/item/clothing/suit/space/hardsuit/engine
+	mask_type = /obj/item/clothing/mask/breath
+
+/obj/machinery/suit_storage_unit/hardsuit/atmospherics
+	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos
+	mask_type = /obj/item/clothing/mask/gas/atmos
+	storage_type = /obj/item/watertank/atmos
+
+/obj/machinery/suit_storage_unit/hardsuit/ce
+	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/elite
+	mask_type = /obj/item/clothing/mask/breath
+	storage_type = /obj/item/clothing/shoes/magboots/advance
+
+/obj/machinery/suit_storage_unit/hardsuit/mining
+	suit_type = /obj/item/clothing/suit/space/hardsuit/mining
+	mask_type = /obj/item/clothing/mask/gas/explorer
+
+/obj/machinery/suit_storage_unit/hardsuit/syndicate
+	suit_type = /obj/item/clothing/suit/space/hardsuit/syndi
+	mask_type = /obj/item/clothing/mask/gas/syndicate
+	storage_type = /obj/item/tank/jetpack/oxygen/harness
+
+/obj/machinery/suit_storage_unit/hardsuit/medical
+	suit_type = /obj/item/clothing/suit/space/hardsuit/medical
+	mask_type = /obj/item/clothing/mask/breath/medical
+	storage_type = /obj/item/tank/internals/oxygen
+
+/obj/machinery/suit_storage_unit/hardsuit/cmo
+	suit_type =	/obj/item/clothing/suit/space/hardsuit/medical/cmo
+	mask_type = /obj/item/clothing/mask/breath/medical
+	storage_type = /obj/item/tank/internals/oxygen
+
+/obj/machinery/suit_storage_unit/hardsuit/security
+	suit_type = /obj/item/clothing/suit/space/hardsuit/security
+	mask_type = /obj/item/clothing/mask/gas/sechailer
+
+/obj/machinery/suit_storage_unit/hardsuit/hos
+	suit_type = /obj/item/clothing/suit/space/hardsuit/security/head_of_security
+	mask_type = /obj/item/clothing/mask/gas/sechailer
+	storage_type = /obj/item/tank/internals/oxygen
+
 /obj/machinery/suit_storage_unit/open
 	state_open = TRUE
 	density = FALSE

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -166,6 +166,7 @@
 	armor = list(MELEE = 40,  BULLET = 5, LASER = 10, ENERGY = 20, BOMB = 50, BIO = 100, FIRE = 100, ACID = 90)
 	heat_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	slowdown = 0.25
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 
 //Mining hardsuit


### PR DESCRIPTION
## About The Pull Request
This PR removes the round start MODsuits from Kilo and replaces them with Hardsuits. The only MODsuits that will spawn roundstart are the following ones:
- Captain MOD (Captain can have a MOD cus hes the big boss and can live in luxury)
- Cargo Loader MOD (Missing a Hardsuit equivelant) 

This PR will also reduce the slowdown of the CE hardsuit significantly because beforehand it was slow like normal hardsuits. 
(Subtypes for hardsuit suit storage units have been created so the mapping changes arent var edit fuckery)
## How Does This Help ***Gameplay***?
Station is a bunch of brokies roundstart and it will provide some nice scaling to the round when people are gonna get their Hardsuits upgraded into MODsuits eventually.

## How Does This Help ***Roleplay***?
Immersion or something? No real impact on Roleplay to be honest.

## Proof of Testing


<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/ed731391-c954-4bfb-b31a-57c50ac351a9)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/c3cd9c49-5d9e-4c1a-8848-d34fed262f87)

</details>

## Changelog

:cl:
add: Added round start Hardsuits to Kilostation.
del: Removed round start MODsuits from Kilostation.
balance: CE Hardsuit now has less slowdown applied to it compared to normal hardsuits.
/:cl: