### PR TITLE
Pathfinders mapping tweaks (Check PR description)

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -56862,9 +56862,7 @@
 "qMG" = (
 /obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/bot,
-/obj/item/flashlight/lamp{
-	pixel_y = 5
-	},
+/obj/item/flashlight/lantern,
 /turf/open/floor/iron/dark/small,
 /area/station/pathfinders/lead_office)
 "qNh" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -8146,6 +8146,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/pathfinders/dock)
 "czy" = (
@@ -12447,20 +12450,16 @@
 /area/station/maintenance/port/lesser)
 "dQc" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/pathfinders_purple/anticorner/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/pathfinders_purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/pathfinders_purple{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/pathfinders/dock)
 "dQx" = (
 /obj/structure/bed/roller,
@@ -19591,6 +19590,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "fQb" = (
@@ -19878,6 +19880,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "fUQ" = (
@@ -20441,6 +20444,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/pathfinders/dock,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/pathfinders/dock)
 "gdr" = (
@@ -22267,6 +22271,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "gDW" = (
@@ -27133,6 +27140,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "hWw" = (
@@ -28989,6 +28997,19 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security)
+"ivV" = (
+/obj/effect/turf_decal/tile/pathfinders_purple/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/pathfinders_purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/pathfinders/dock)
 "ivY" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -35313,6 +35334,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"kqR" = (
+/obj/effect/turf_decal/tile/pathfinders_purple/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/pathfinders_purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/pathfinders/dock)
 "kra" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38627,6 +38661,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/floor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/pathfinders/dock)
 "loI" = (
@@ -39557,8 +39592,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
@@ -39712,6 +39747,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/pathfinders/dock)
 "lDB" = (
@@ -42398,7 +42434,6 @@
 /obj/effect/turf_decal/tile/pathfinders_purple{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/tile/pathfinders_purple{
 	dir = 4
 	},
@@ -42408,6 +42443,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "mwe" = (
@@ -48694,18 +48730,24 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "ovL" = (
-/obj/effect/turf_decal/tile/pathfinders_purple/half/contrasted{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/pathfinders_purple/anticorner/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/pathfinders_purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/pathfinders_purple{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "ovN" = (
@@ -49501,11 +49543,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
 "oHs" = (
-/obj/effect/turf_decal/tile/pathfinders_purple/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/pathfinders_purple/anticorner/contrasted{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/pathfinders_purple{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/pathfinders_purple{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
@@ -56049,6 +56094,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "qzJ" = (
@@ -57778,6 +57826,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "qYO" = (
@@ -58691,6 +58742,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "roy" = (
@@ -60552,6 +60606,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/pathfinders/dock,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/pathfinders/dock)
 "rOq" = (
@@ -61159,6 +61214,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "rWT" = (
@@ -61361,6 +61417,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/pathfinders/dock)
 "sav" = (
@@ -71855,6 +71914,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vbL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/pathfinders_purple{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/pathfinders/dock)
 "vbP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -125325,7 +125394,7 @@ wrR
 wrR
 tCE
 ovL
-fUO
+vbL
 fUO
 fUO
 saj
@@ -126355,7 +126424,7 @@ xHC
 iJx
 vuW
 rWl
-pxQ
+kqR
 eUp
 wfe
 tYL
@@ -126869,7 +126938,7 @@ jmW
 mur
 cDv
 jaq
-cdy
+ivV
 kBj
 drn
 jXS

--- a/_maps/shuttles/pathfinders_ghetto.dmm
+++ b/_maps/shuttles/pathfinders_ghetto.dmm
@@ -10,8 +10,8 @@
 "c" = (
 /obj/structure/table,
 /obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space,
 /obj/effect/turf_decal/tile/pathfinders_purple/half,
+/obj/item/clothing/head/helmet/space/eva,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/ghetto)
 "d" = (
@@ -207,9 +207,6 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/pathfinders_purple/half{
 	dir = 8
 	},


### PR DESCRIPTION
## About The Pull Request
Does what it says on the packaging. It adds a disposal bin to the pathfinders dock and a cable leading to the shuttle docking port so the pathfinder shuttle can re-charge when its docked. Random vent has also been removed from the pathfinders shuttle.

## How Does This Help ***Gameplay***?
Qol for pathfinders when they want to toss something away or charge their shuttle when its docked at the station.

## How Does This Help ***Roleplay***?
Minimal impact on Roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/45b83aab-041d-4a83-85bb-e2e767f6c71a)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/8e27eca2-5458-44d6-8c95-fff2d285d557)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/ee4f3799-a01f-48e0-8000-041d31deaba2)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/84603f78-d09e-4e0d-a884-8776a2eafbf2)

</details>

## Changelog
:cl:
add: Added a disposal bin to pathfinders dock and a power cable leading to the shuttle docking port.
del: Removed a random vent on the pathfinders shuttle.
/:cl: