### PR TITLE
Fix Pathfinder Shuttle Being Unable To Dock At Station

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -16405,10 +16405,11 @@
 /obj/docking_port/stationary/mining_home/kilo{
 	dir = 4;
 	name = "SS13: Pathfinders Dock";
-	shuttle_id = "pathfinders";
-	width = 9;
+	shuttle_id = "pathfinders_home";
+	width = 11;
 	dwidth = 4;
-	roundstart_template = /datum/map_template/shuttle/pathfinders/ghetto
+	roundstart_template = /datum/map_template/shuttle/pathfinders/ghetto;
+	height = 14
 	},
 /turf/open/space/basic,
 /area/space)


### PR DESCRIPTION
## About The Pull Request

Tin.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/a956afee-db5f-4029-b3cf-23c0376e520a)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Pathfinder shuttle can once again dock at the station.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
