### PR TITLE
Pathfinder Lead is Now Part of CoC, CoC Priority Tweaks

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -44,10 +44,11 @@ SUBSYSTEM_DEF(job)
 	var/list/chain_of_command = list(
 		JOB_CAPTAIN = 1,
 		JOB_HEAD_OF_PERSONNEL = 2,
+		JOB_QUARTERMASTER = 5,
 		JOB_CHIEF_ENGINEER = 3,
 		JOB_CHIEF_MEDICAL_OFFICER = 4,
-		JOB_HEAD_OF_SECURITY = 5,
-		JOB_QUARTERMASTER = 6,
+		JOB_HEAD_OF_SECURITY = 6,
+		JOB_PATHFINDER_LEAD = 7, // This is last because the pathfinder lead is the least likely one to be able to stay on the station.
 	)
 
 	/// If TRUE, some player has been assigned Captaincy or Acting Captaincy at some point during the shift and has been given the spare ID safe code.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -44,9 +44,9 @@ SUBSYSTEM_DEF(job)
 	var/list/chain_of_command = list(
 		JOB_CAPTAIN = 1,
 		JOB_HEAD_OF_PERSONNEL = 2,
-		JOB_QUARTERMASTER = 5,
-		JOB_CHIEF_ENGINEER = 3,
-		JOB_CHIEF_MEDICAL_OFFICER = 4,
+		JOB_QUARTERMASTER = 3,
+		JOB_CHIEF_ENGINEER = 4,
+		JOB_CHIEF_MEDICAL_OFFICER = 5,
 		JOB_HEAD_OF_SECURITY = 6,
 		JOB_PATHFINDER_LEAD = 7, // This is last because the pathfinder lead is the least likely one to be able to stay on the station.
 	)


### PR DESCRIPTION
## About The Pull Request

Closes #246 

Tin.

QM is a proper head here (and arguably does very little compared to other heads), and arguably has more authority than the HoS, CMO, and Pathfinder Leader, so they've been bumped up to just under HoP.
CE is low on the list because they have a shitton to do already, and HoS is low to prevent an armed-to-the-teeth gigasecoff.

PL is last on the list, because they have very little interest on being on-station, so let's not dump captainship on them unless we literally have no other choice.

## How Does This Help ***Gameplay***?

Oh look, the PL no longer has to wait 2 minutes for their captain ID.

## How Does This Help ***Roleplay***?

"I'm a *real* head now!"

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/d2270a3c-494e-4322-aa68-55329c866825)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: QM is now 2nd in line for acting captaincy.
fix: Pathfinder Lead is now considered for captainship.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
