### PR TITLE
Pathfinders Now Show In Job Preferences

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
@@ -369,7 +369,7 @@ export const JobsPage = () => {
                 <Gap amount={6} />
               </Department>
 
-              <Department department="Science">
+              <Department department="Pathfinders">
                 <Gap amount={6} />
               </Department>
 

--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -14,6 +14,7 @@ $department_map: (
   'Science': colors.fg(colors.$purple),
   'Service': colors.$green,
   'Silicon': colors.$pink,
+  'Pathfinders': #847a96,
 );
 
 .PreferencesMenu {


### PR DESCRIPTION
## About The Pull Request

Tin. Woops.

Closes #245 

## Proof of Testing

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/761f0149-27ce-479e-a37e-0a4bc37ca26e)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Pathfinders can now have their job preferences set!
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
