### PR TITLE
Fixes Being Able To Knock Electrified Doors Without Shock

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -768,11 +768,12 @@
 
 /obj/machinery/door/airlock/attack_hand(mob/user, list/modifiers)
 	. = ..()
-	if(.)
-		return
 	if(!(issilicon(user) || isAdminGhostAI(user)))
 		if(isElectrified() && shock(user, 100))
 			return
+
+	if(.)
+		return
 
 	if(ishuman(user) && prob(40) && density)
 		var/mob/living/carbon/human/H = user


### PR DESCRIPTION
## About The Pull Request

Haha, woops.

## How Does This Help ***Roleplay***?

Nope, knocking a door indeed does *not* grant you shock immunity!

## Proof of Testing

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/de228450-11b1-4a25-9f24-097d81078d09)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/dd4baf00-1882-4100-8435-f13729dfd860)


You'll still knock the door, but you'll be on your ass for it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: You can no longer knock on electrified doors.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
