### PR TITLE
Makes Foam Grenades Also Pass Through Open Atmos Turfs

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -129,7 +129,7 @@
 	if(!istype(location))
 		return FALSE
 
-	for(var/turf/spread_turf as anything in location.reachableAdjacentTurfs(no_id = TRUE))
+	for(var/turf/spread_turf as anything in location.reachableAdjacentTurfs(no_id = TRUE) | location.get_atmos_adjacent_turfs())
 		var/obj/effect/particle_effect/fluid/foam/foundfoam = locate() in spread_turf //Don't spread foam where there's already foam!
 		if(foundfoam)
 			continue


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/75791 (The issues raised here do not apply to us, as shown)

Tl;dr, makes it so foam grenades (construction foam included!) able to pass through tables and machines.

Makes them actually useful outside of hallways,

## How Does This Help ***Gameplay***?

Foam now works as most unfamiliar players would expect, engineers actually have a viable quick-repair method that isn't the RCD!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/c1fdd5ac-04c8-45bc-bbb6-c65f886a89a1)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/580b759e-eb30-480d-aaa2-67eacbb874af)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/e53006a3-c8ef-4263-b643-00d0e769f593)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Foam now passes through open atmos tiles.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
