### PR TITLE
Adds Hardsuit outfits to all jobs that could need one.

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -345,6 +345,7 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/medical
 	slowdown = 0.5
 
+//CMO hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/medical/cmo
 	name = "chief medical officer's hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Built with lightweight materials for extra comfort and protects the eyes from intense light."

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -23,3 +23,13 @@
 	back = /obj/item/mod/control/pre_equipped/atmospheric
 	mask = /obj/item/clothing/mask/gas/atmos
 	internals_slot = ITEM_SLOT_SUITSTORE
+
+/datum/outfit/job/atmos/hardsuit
+	name = "Atmospheric Technician (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine/atmos
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE
+

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -32,4 +32,3 @@
 	suit = /obj/item/clothing/suit/space/hardsuit/engine/atmos
 	suit_store = /obj/item/tank/internals/oxygen
 	internals_slot = ITEM_SLOT_SUITSTORE
-

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -89,3 +89,15 @@
 	mask = /obj/item/clothing/mask/breath
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	internals_slot = ITEM_SLOT_SUITSTORE
+
+/datum/outfit/job/ce/hardsuit
+	name = "Chief Engineer (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine/elite
+	suit_store = /obj/item/tank/internals/oxygen
+	gloves = /obj/item/clothing/gloves/color/yellow
+	glasses = /obj/item/clothing/glasses/meson/engine
+	shoes = /obj/item/clothing/shoes/magboots/advance
+	internals_slot = ITEM_SLOT_SUITSTORE

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -90,3 +90,14 @@
 	mask = /obj/item/clothing/mask/breath/medical
 	r_pocket = /obj/item/flashlight/pen/paramedic
 	internals_slot = ITEM_SLOT_SUITSTORE
+
+/datum/outfit/job/cmo/hardsuit
+	name = "Chief Medical Officer (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath/medical
+	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer
+	suit = /obj/item/clothing/suit/space/hardsuit/medical/cmo
+	r_pocket = /obj/item/flashlight/pen/paramedic
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -90,7 +90,7 @@
 	name = "Head of Security (Hardsuit)"
 
 	head = null
-	mask = mask = /obj/item/clothing/mask/gas/sechailer
+	mask = /obj/item/clothing/mask/gas/sechailer
 	suit = /obj/item/clothing/suit/space/hardsuit/security/head_of_security
 	suit_store = /obj/item/tank/internals/oxygen
 	internals_slot = ITEM_SLOT_SUITSTORE

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -85,3 +85,12 @@
 	head = null
 	mask = /obj/item/clothing/mask/gas/sechailer
 	internals_slot = ITEM_SLOT_SUITSTORE
+
+/datum/outfit/job/hos/hardsuit
+	name = "Head of Security (Hardsuit)"
+
+	head = null
+	mask = mask = /obj/item/clothing/mask/gas/sechailer
+	suit = /obj/item/clothing/suit/space/hardsuit/security/head_of_security
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -72,3 +72,12 @@
 	mask = /obj/item/clothing/mask/breath/medical
 	r_pocket = /obj/item/flashlight/pen
 	internals_slot = ITEM_SLOT_SUITSTORE
+
+/datum/outfit/job/doctor/hardsuit
+	name = "Medical Docotor (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath/medical
+	suit = /obj/item/clothing/suit/space/hardsuit/medical
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -234,6 +234,15 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	mask = /obj/item/clothing/mask/gas/sechailer
 	internals_slot = ITEM_SLOT_SUITSTORE
 
+/datum/outfit/job/security/hardsuit
+	name = "Security Officer (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/gas/sechailer
+	suit = /obj/item/clothing/suit/space/hardsuit/security
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE
+
 /obj/item/radio/headset/headset_sec/alt/department/Initialize(mapload)
 	. = ..()
 	wires = new/datum/wires/radio(src)

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -73,3 +73,12 @@
 	head = null
 	mask = /obj/item/clothing/mask/breath
 	internals_slot = ITEM_SLOT_SUITSTORE
+
+/datum/outfit/job/engineer/hardsuit
+	name = "Station Engineer (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE

--- a/code/modules/pathfinders/pathfinder_job.dm
+++ b/code/modules/pathfinders/pathfinder_job.dm
@@ -57,6 +57,15 @@
 	mask = /obj/item/clothing/mask/breath
 	internals_slot = ITEM_SLOT_SUITSTORE
 
+/datum/outfit/job/pathfinder/hardsuit
+	name = "Pathfinder (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/mining
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE
+
 // These are mostly for admeme intervention efforts.
 /datum/outfit/job/pathfinder/medic
 	name = "Pathfinder Medic"

--- a/code/modules/pathfinders/pathfinder_lead_job.dm
+++ b/code/modules/pathfinders/pathfinder_lead_job.dm
@@ -68,6 +68,15 @@
 	mask = /obj/item/clothing/mask/breath
 	internals_slot = ITEM_SLOT_SUITSTORE
 
+/datum/outfit/job/lead_pathfinder/hardsuit
+	name = "Lead Pathfinder (Hardsuit)"
+
+	head = null
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/mining
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE
+
 /datum/id_trim/job/lead_pathfinder
 	assignment = "Lead Pathfinder"
 	intern_alt_name = "Honorary Lead Pathfinder"


### PR DESCRIPTION
## About The Pull Request
Does what it says in the title, this adds outfit datums with hardsuits equipped to each relevant job that needs one, nothing else really. I forgot to do this in the initial hardsuit PR (#219) so here we are lol 

## How Does This Help ***Gameplay***?
Minimal impact on gameplay. This is more meant for admins to use anyways like all outfit datums.

## How Does This Help ***Roleplay***?
Minimal impact on roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/058a3e88-58a4-4235-8d3c-de96e914a9b9)

</details>

## Changelog
:cl:
add: Added Hardsuit outfits to jobs that have hardsuits.
/:cl: