### PR TITLE
[PORT] Potted plant revival!

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -666,7 +666,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/secure_storage)
 "kA" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/airless,
@@ -806,7 +806,7 @@
 /area/space/nearstation)
 "mp" = (
 /obj/structure/sign/departments/medbay/alt/directional/west,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/hallway/central)
 "mv" = (
@@ -3547,7 +3547,7 @@
 "Cn" = (
 /obj/structure/sign/departments/medbay/alt/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/hallway/central)
 "Co" = (
@@ -3917,7 +3917,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/tool_storage)
 "Eg" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/hallway/central)
 "Ej" = (
@@ -4259,7 +4259,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/grav_gen)
 "Ge" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/security/court)
@@ -5774,7 +5774,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/science/rnd)
 "Og" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/security/court)
 "Oh" = (
@@ -6146,7 +6146,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/singulo)
 "PT" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/command/bridge)
@@ -6918,7 +6918,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/security/sec)
 "TA" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/command/bridge_hall)
 "TB" = (
@@ -7654,7 +7654,7 @@
 /area/ruin/space/ks13/science/genetics)
 "Xs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/cafe)
 "Xt" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -21221,7 +21221,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -17547,7 +17547,7 @@
 	},
 /obj/structure/sign/warning/yes_smoking/circle/directional/south,
 /obj/machinery/light/small/directional/south,
-/obj/item/kirbyplants/dead{
+/obj/item/kirbyplants/random/dead{
 	name = "Lungie"
 	},
 /turf/open/floor/iron/white,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7273,7 +7273,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "cEH" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/random/dead,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/cafeteria{
 	dir = 5

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -223,7 +223,7 @@
 /turf/open/floor/wood,
 /area/shuttle/transport)
 "bd" = (
-/obj/item/kirbyplants/dead{
+/obj/item/kirbyplants/random/dead{
 	desc = "It doesn't look very healthy...";
 	name = "potted plant"
 	},

--- a/code/game/objects/items/kirbyplants.dm
+++ b/code/game/objects/items/kirbyplants.dm
@@ -116,6 +116,7 @@
 /obj/item/kirbyplants/random/fullysynthetic
 	name = "plastic potted plant"
 	desc = "A fake, cheap looking, plastic tree. Perfect for people who kill every plant they touch."
+	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "plant-26"
 	custom_materials = (list(/datum/material/plastic = 8000))
 	trimmable = FALSE

--- a/code/game/objects/items/kirbyplants.dm
+++ b/code/game/objects/items/kirbyplants.dm
@@ -3,6 +3,7 @@
 	name = "potted plant"
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "plant-01"
+	base_icon_state = "plant-01"
 	desc = "A little bit of nature contained in a pot."
 	layer = ABOVE_MOB_LAYER
 	plane = GAME_PLANE
@@ -15,6 +16,10 @@
 
 	/// Can this plant be trimmed by someone with TRAIT_BONSAI
 	var/trimmable = TRUE
+	/// Whether this plant is dead and requires a seed to revive
+	var/dead = FALSE
+	///If it's a special named plant, set this to true to prevent dead-name overriding.
+	var/custom_plant_name = FALSE
 	var/list/static/random_plant_states
 
 /obj/item/kirbyplants/Initialize(mapload)
@@ -22,14 +27,42 @@
 	AddComponent(/datum/component/tactical)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
 	AddElement(/datum/element/beauty, 500)
+	if(icon_state != base_icon_state && icon_state != "plant-25") //mapedit support
+		base_icon_state = icon_state
+	update_appearance()
+
+/obj/item/kirbyplants/update_name(updates)
+	. = ..()
+	if(custom_plant_name)
+		return
+	name = "[dead ? "dead ":null][initial(name)]"
+
+/obj/item/kirbyplants/update_desc(updates)
+	. = ..()
+	desc = dead ? "The unidentifiable plant remnants make you feel like planting something new in the pot." : initial(desc)
+
+/obj/item/kirbyplants/vv_edit_var(vname, vval)
+	. = ..()
+	if(vname == NAMEOF(src, dead))
+		update_appearance()
+
+/obj/item/kirbyplants/update_icon_state()
+	. = ..()
+	icon_state = dead ? "plant-25" : base_icon_state
 
 /obj/item/kirbyplants/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
-	if(trimmable && HAS_TRAIT(user,TRAIT_BONSAI) && isturf(loc) && I.get_sharpness())
+	if(!dead &&trimmable && HAS_TRAIT(user,TRAIT_BONSAI) && isturf(loc) && I.get_sharpness())
 		to_chat(user,span_notice("You start trimming [src]."))
 		if(do_after(user,3 SECONDS,target=src))
 			to_chat(user,span_notice("You finish trimming [src]."))
 			change_visual()
+	if(dead && istype(I, /obj/item/seeds))
+		to_chat(user,span_notice("You start planting a new seed into the pot."))
+		if(do_after(user,3 SECONDS,target=src))
+			qdel(I)
+			dead = FALSE
+			update_appearance()
 
 /// Cycle basic plant visuals
 /obj/item/kirbyplants/proc/change_visual()
@@ -37,22 +70,12 @@
 		generate_states()
 	var/current = random_plant_states.Find(icon_state)
 	var/next = WRAP(current+1,1,length(random_plant_states))
-	icon_state = random_plant_states[next]
-
-/obj/item/kirbyplants/random
-	icon = 'icons/obj/flora/_flora.dmi'
-	icon_state = "random_plant"
-
-/obj/item/kirbyplants/random/Initialize(mapload)
-	. = ..()
-	icon = 'icons/obj/flora/plants.dmi'
-	if(!random_plant_states)
-		generate_states()
-	icon_state = pick(random_plant_states)
+	base_icon_state = random_plant_states[next]
+	update_appearance(UPDATE_ICON)
 
 /obj/item/kirbyplants/proc/generate_states()
 	random_plant_states = list()
-	for(var/i in 1 to 25)
+	for(var/i in 1 to 24)
 		var/number
 		if(i < 10)
 			number = "0[i]"
@@ -61,12 +84,46 @@
 		random_plant_states += "plant-[number]"
 	random_plant_states += "applebush"
 
+/obj/item/kirbyplants/random
+	icon = 'icons/obj/flora/_flora.dmi'
+	icon_state = "random_plant"
 
-/obj/item/kirbyplants/dead
-	name = "RD's potted plant"
-	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"\nIt doesn't look very healthy..."
+/obj/item/kirbyplants/random/Initialize(mapload)
+	. = ..()
+	icon = 'icons/obj/flora/plants.dmi'
+	randomize_base_icon_state()
+
+//Handles randomizing the icon during initialize()
+/obj/item/kirbyplants/random/proc/randomize_base_icon_state()
+	if(!random_plant_states)
+		generate_states()
+	base_icon_state = pick(random_plant_states)
+	if(!dead) //no need to update the icon if we're already dead.
+		update_appearance(UPDATE_ICON)
+
+/obj/item/kirbyplants/random/dead
 	icon_state = "plant-25"
+	dead = TRUE
+
+/obj/item/kirbyplants/random/dead/research_director
+	name = "RD's potted plant"
+	custom_plant_name = TRUE
+
+/obj/item/kirbyplants/random/dead/update_desc(updates)
+	. = ..()
+	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"[dead ? "\nIt doesn't look very healthy...":null]"
+
+/obj/item/kirbyplants/random/fullysynthetic
+	name = "plastic potted plant"
+	desc = "A fake, cheap looking, plastic tree. Perfect for people who kill every plant they touch."
+	icon_state = "plant-26"
+	custom_materials = (list(/datum/material/plastic = 8000))
 	trimmable = FALSE
+
+//Handles randomizing the icon during initialize()
+/obj/item/kirbyplants/random/fullysynthetic/randomize_base_icon_state()
+	base_icon_state = "plant-[rand(26, 29)]"
+	update_appearance(UPDATE_ICON)
 
 /obj/item/kirbyplants/photosynthetic
 	name = "photosynthetic potted plant"
@@ -75,21 +132,11 @@
 	light_color = COLOR_BRIGHT_BLUE
 	light_range = 3
 
-/obj/item/kirbyplants/fullysynthetic
-	name = "plastic potted plant"
-	desc = "A fake, cheap looking, plastic tree. Perfect for people who kill every plant they touch."
-	icon_state = "plant-26"
-	custom_materials = (list(/datum/material/plastic = 8000))
-	trimmable = FALSE
-
-/obj/item/kirbyplants/fullysynthetic/Initialize(mapload)
-	. = ..()
-	icon_state = "plant-[rand(26, 29)]"
-
 /obj/item/kirbyplants/potty
 	name = "Potty the Potted Plant"
 	desc = "A secret agent staffed in the station's bar to protect the mystical cakehat."
 	icon_state = "potty"
+	custom_plant_name = TRUE
 	trimmable = FALSE
 
 /obj/item/kirbyplants/fern

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1722,7 +1722,7 @@
 	id = "plastic_trees"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/plastic = 8000)
-	build_path = /obj/item/kirbyplants/fullysynthetic
+	build_path = /obj/item/kirbyplants/random/fullysynthetic
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE


### PR DESCRIPTION
## About The Pull Request
This PR will allow you to revive the dead potted plant with seeds. It works with any type of seeds and will always result in a randomly chosen icon_state getting applied to the newly revived pant.

This PR ports:
- https://github.com/tgstation/tgstation/pull/75602
- https://github.com/tgstation/tgstation/pull/75929 (Fixes because 75602 broke some stuff, mainly the Iconstate changing when plants were being thrown)
## How Does This Help ***Gameplay***?
Players now have a way to revive those ugly dead plants, Yippee

## How Does This Help ***Roleplay***?
Minimal impact on Roleplay.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/0972f2ed-ea75-452f-b88b-496f1b2d9039

</details>

## Changelog
:cl:
qol: dead potted plant can be revived with seeds
/:cl: