### PR TITLE
[PORT] Speaking in Sign language no longer reveals your identity.

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 			continue
 		hearing_movable.Hear(rendered, src, message_language, message, , spans, message_mods)
 
-/atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE)
+/atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE, visible_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.
 	//Basic span
 	var/spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
@@ -94,6 +94,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if(face_name && ishuman(speaker))
 		var/mob/living/carbon/human/H = speaker
 		namepart = "[H.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised
+	else if(visible_name && ishuman(speaker))
+		var/mob/living/carbon/human/human_speaker = speaker
+		namepart = "[human_speaker.get_visible_name()]" //For if the message can be seen but not heard, shows "speaker"'s visible identity (like when using sign language)
 	//End name span.
 	var/endspanpart = "</span>"
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -261,7 +261,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		avoid_highlight = src == speaker
 
 	if(HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) //Checks if speaker is using sign language
-		deaf_message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
+		deaf_message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods, FALSE, TRUE)
 		if(speaker != src)
 			if(!radio_freq) //I'm about 90% sure there's a way to make this less cluttered
 				deaf_type = 1


### PR DESCRIPTION
## About The Pull Request
This PR is a port of:
- https://github.com/tgstation/tgstation/pull/75606

### Testing for this PR is currently impossible because the mute quirk doesn't work 🙃 
Just uhhh trust me on this one, it works I think.

## How Does This Help ***Gameplay***?
Speaking in sign language no longer outs who you are so thats nice for any mute antags.

## How Does This Help ***Roleplay***?
You can be more of a sneaky antag when you're mute, leading to potentially better roleplay scenarios.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/e7f3b05d-a889-4405-a065-653b85c8db1b)

It returns no errors but testing for this is currently impossible because all the quirks are broken rn.

</details>

## Changelog
:cl:
fix: Speaking in sign language no longer reveals your identity
/:cl: