### PR TITLE
Voice Prefs!

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -176,3 +176,12 @@ GLOBAL_LIST_INIT(announcer_keys, list(
 #define SFX_SWITCH "switch"
 #define SFX_KEYBOARD "keyboard"
 #define SFX_PDA "pda"
+
+#define VOICE_HUMAN_M "Human Male"
+#define VOICE_HUMAN_F "Human Female"
+#define VOICE_LIZARD_M "Lizard Male"
+#define VOICE_LIZARD_F "Lizard Female"
+#define VOICE_MOTH_M "Moth Male"
+#define VOICE_MOTH_F "Moth Female"
+#define VOICE_ETHEREAL_M "Ethereal Male"
+#define VOICE_ETHEREAL_F "Ethereal Female"

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -78,6 +78,8 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	var/stability = 100
 	///Did we take something like mutagen? In that case we cant get our genes scanned to instantly cheese all the powers.
 	var/scrambled = FALSE
+	///If non-null, try to use this instead for screams and other voiced emotes.
+	var/voice_type
 
 /datum/dna/New(mob/living/new_holder)
 	if(istype(new_holder))
@@ -109,6 +111,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	destination.dna.inspection_text = inspection_text.Copy()
 	destination.dna.real_name = real_name
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
+	destination.dna.voice_type = voice_type
 	if(transfer_SE)
 		destination.dna.mutation_index = mutation_index
 		destination.dna.default_mutation_genes = default_mutation_genes
@@ -127,6 +130,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	new_dna.species = new species.type
 	new_dna.species.species_traits = species.species_traits
 	new_dna.real_name = real_name
+	new_dna.voice_type = voice_type
 	// Mutations aren't gc managed, but they still aren't templates
 	// Let's do a proper copy
 	for(var/datum/mutation/human/mutation in mutations)

--- a/code/modules/client/preferences/voice.dm
+++ b/code/modules/client/preferences/voice.dm
@@ -1,0 +1,22 @@
+/datum/preference/choiced/voice
+	category = PREFERENCE_CATEGORY_APPEARANCE_LIST
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "voice"
+
+/datum/preference/choiced/voice/init_possible_values()
+	return list(
+		VOICE_HUMAN_M,
+		VOICE_HUMAN_F,
+		VOICE_LIZARD_M,
+		VOICE_LIZARD_F,
+		VOICE_MOTH_M,
+		VOICE_MOTH_F,
+		VOICE_ETHEREAL_M,
+		VOICE_ETHEREAL_F,
+	)
+
+/datum/preference/choiced/voice/create_default_value()
+	return pick(get_choices())
+
+/datum/preference/choiced/voice/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	target.dna.voice_type = value

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -60,7 +60,6 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
-	only_forced_audio = TRUE
 	vary = TRUE
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/carbon/human/user)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1947,9 +1947,63 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/prepare_human_for_preview(mob/living/carbon/human/human)
 	return
 
-/// Returns the species's scream sound.
+/// Returns the species's scream sound, or if there's a DNA override, use that instead.
 /datum/species/proc/get_scream_sound(mob/living/carbon/human/human)
-	return
+	var/scream_type = human.dna.voice_type
+	if(!scream_type)
+		switch(human.dna.species.id)
+			if(SPECIES_HUMAN)
+				if(human.gender == MALE)
+					scream_type = VOICE_HUMAN_M
+				else
+					scream_type = VOICE_HUMAN_F
+			if(SPECIES_LIZARD)
+				scream_type = human.gender == MALE ? VOICE_LIZARD_M : VOICE_LIZARD_F
+			if(SPECIES_MOTH)
+				scream_type = human.gender == MALE ? VOICE_MOTH_M : VOICE_MOTH_F
+			if(SPECIES_SYNTH)
+				scream_type = human.gender == MALE ? VOICE_ETHEREAL_M : VOICE_ETHEREAL_F
+
+	switch(scream_type)
+		if(VOICE_HUMAN_M)
+			if(prob(1))
+				return 'sound/voice/human/wilhelm_scream.ogg'
+			return pick(
+				'sound/voice/human/malescream_1.ogg',
+				'sound/voice/human/malescream_2.ogg',
+				'sound/voice/human/malescream_3.ogg',
+				'sound/voice/human/malescream_4.ogg',
+				'sound/voice/human/malescream_5.ogg',
+				'sound/voice/human/malescream_6.ogg',
+			)
+
+		if(VOICE_HUMAN_F)
+			return pick(
+				'sound/voice/human/femalescream_1.ogg',
+				'sound/voice/human/femalescream_2.ogg',
+				'sound/voice/human/femalescream_3.ogg',
+				'sound/voice/human/femalescream_4.ogg',
+				'sound/voice/human/femalescream_5.ogg',
+			)
+
+		if(VOICE_LIZARD_M, VOICE_LIZARD_F)
+			return pick(
+				'sound/voice/lizard/lizard_scream_1.ogg',
+				'sound/voice/lizard/lizard_scream_2.ogg',
+				'sound/voice/lizard/lizard_scream_3.ogg',
+			)
+
+		if(VOICE_MOTH_M, VOICE_MOTH_F)
+			return 'sound/voice/moth/scream_moth.ogg'
+
+		if(VOICE_ETHEREAL_M, VOICE_ETHEREAL_F)
+			return pick(
+				'sound/voice/ethereal/ethereal_scream_1.ogg',
+				'sound/voice/ethereal/ethereal_scream_2.ogg',
+				'sound/voice/ethereal/ethereal_scream_3.ogg',
+			)
+
+	return // Uhhh, just be silent?? I dunno!
 
 /datum/species/proc/get_types_to_preload()
 	var/list/to_store = list()

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -175,13 +175,6 @@
 
 	return features
 
-/datum/species/ethereal/get_scream_sound(mob/living/carbon/human/ethereal)
-	return pick(
-		'sound/voice/ethereal/ethereal_scream_1.ogg',
-		'sound/voice/ethereal/ethereal_scream_2.ogg',
-		'sound/voice/ethereal/ethereal_scream_3.ogg',
-	)
-
 /datum/species/ethereal/get_species_description()
 	return "Coming from the planet of Sprout, the theocratic ethereals are \
 		separated socially by caste, and espouse a dogma of aiding the weak and \

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -30,27 +30,6 @@
 /datum/species/human/randomize_features(mob/living/carbon/human/human_mob)
 	human_mob.skin_tone = random_skin_tone()
 
-/datum/species/human/get_scream_sound(mob/living/carbon/human/human)
-	if(human.gender == MALE)
-		if(prob(1))
-			return 'sound/voice/human/wilhelm_scream.ogg'
-		return pick(
-			'sound/voice/human/malescream_1.ogg',
-			'sound/voice/human/malescream_2.ogg',
-			'sound/voice/human/malescream_3.ogg',
-			'sound/voice/human/malescream_4.ogg',
-			'sound/voice/human/malescream_5.ogg',
-			'sound/voice/human/malescream_6.ogg',
-		)
-
-	return pick(
-		'sound/voice/human/femalescream_1.ogg',
-		'sound/voice/human/femalescream_2.ogg',
-		'sound/voice/human/femalescream_3.ogg',
-		'sound/voice/human/femalescream_4.ogg',
-		'sound/voice/human/femalescream_5.ogg',
-	)
-
 /datum/species/human/get_species_description()
 	return "Humans are the dominant species in the known galaxy. \
 		Their kind extend from old Earth to the edges of known space."

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -75,13 +75,6 @@
 	human_mob.dna.features["body_markings"] = pick(GLOB.body_markings_list)
 	randomize_external_organs(human_mob)
 
-/datum/species/lizard/get_scream_sound(mob/living/carbon/human/lizard)
-	return pick(
-		'sound/voice/lizard/lizard_scream_1.ogg',
-		'sound/voice/lizard/lizard_scream_2.ogg',
-		'sound/voice/lizard/lizard_scream_3.ogg',
-	)
-
 /datum/species/lizard/get_species_description()
 	return "The militaristic Lizardpeople hail originally from Tizira, but have grown \
 		throughout their centuries in the stars to possess a large spacefaring \

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -67,9 +67,6 @@
 	human_mob.dna.features["moth_markings"] = pick(GLOB.moth_markings_list)
 	randomize_external_organs(human_mob)
 
-/datum/species/moth/get_scream_sound(mob/living/carbon/human/human)
-	return 'sound/voice/moth/scream_moth.ogg'
-
 /datum/species/moth/get_species_description()
 	return "Hailing from a planet that was lost long ago, the moths travel \
 		the galaxy as a nomadic people aboard a colossal fleet of ships, seeking a new homeland."

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -256,7 +256,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.dna.species.id == SPECIES_HUMAN && (!H.mind || !H.mind.miming))
-			if(user.gender == FEMALE)
+			if((!H.dna.voice_type && H.gender == FEMALE) || findtext(H.dna.voice_type, "Female"))
 				return 'sound/voice/human/womanlaugh.ogg'
 			else
 				return pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg')

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2750,6 +2750,7 @@
 #include "code\modules\client\preferences\ui_style.dm"
 #include "code\modules\client\preferences\underwear_color.dm"
 #include "code\modules\client\preferences\uplink_location.dm"
+#include "code\modules\client\preferences\voice.dm"
 #include "code\modules\client\preferences\widescreen.dm"
 #include "code\modules\client\preferences\window_flashing.dm"
 #include "code\modules\client\preferences\middleware\_middleware.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/voice.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/voice.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../base';
+
+export const voice: FeatureChoiced = {
+  name: 'Voice',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request

Something something femboys, uhhh-

Yea!

Adds a new pref for screams and laughs, and allows for every TG roundstart race's sounds to be used.

Ethereal screams were kept because they make sense for synths.

Each race has a male/female discriminator to make it easier for coders to implement gendered sounds in the future.

## How Does This Help ***Gameplay***?

Better representation in laughs and screams.

## How Does This Help ***Roleplay***?

Uhhh, more accurater screes!

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/e4a0917a-8ade-49a3-b17e-dc118101d9e4)

Screams work as intended.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Voice prefs!
qol: Scream audio is no longer for forced screams only.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
