### PR TITLE
Fix: Runtime in modsuit maint program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
@@ -18,7 +18,7 @@
 
 /datum/computer_file/program/maintenance/modsuit_control/application_attackby(obj/item/attacking_item, mob/living/user)
 	. = ..()
-	if(!istype(attacking_item, controlled_suit))
+	if(!istype(attacking_item, /obj/item/mod/control))
 		return FALSE
 	if(controlled_suit)
 		unsync_modsuit()
@@ -39,11 +39,12 @@
 	return data
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_static_data(mob/user)
-	return controlled_suit.ui_static_data()
+	if(controlled_suit)
+		return controlled_suit.ui_static_data()
+	return ..()
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
-
-	controlled_suit.ui_act(action, params, ui)
+	controlled_suit?.ui_act(action, params, ui)


### PR DESCRIPTION
## About The Pull Request

This PR fixes the following runtimes we saw in the recent playtest:

```
Runtime in modsuit.dm, line 42: Cannot execute null.ui static data().
proc name: ui static data (/datum/computer_file/program/maintenance/modsuit_control/ui_static_data)
usr: GuiltyNeko/(Woodrow Brindle)
usr.loc: (Delivery Office (128,135,4))
src: /datum/computer_file/program/m... (/datum/computer_file/program/maintenance/modsuit_control)
call stack:
/datum/computer_file/program/m... (/datum/computer_file/program/maintenance/modsuit_control): ui static data(Woodrow Brindle (/mob/living/carbon/human))
Woodrow Brindle (Chief Enginee... (/obj/item/modular_computer/pda/heads/ce): ui static data(Woodrow Brindle (/mob/living/carbon/human))
/datum/tgui (/datum/tgui): get payload(null, 1, 1)
/datum/tgui (/datum/tgui): send full update(null, null)
/datum/callback (/datum/callback): Invoke()
world: push usr(Woodrow Brindle (/mob/living/carbon/human), /datum/callback (/datum/callback))
/datum/callback (/datum/callback): InvokeAsync()
Timer (/datum/controller/subsystem/timer): fire(0)
Timer (/datum/controller/subsystem/timer): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```

```
Runtime in modsuit.dm, line 49: Cannot execute null.ui act().
proc name: ui act (/datum/computer_file/program/maintenance/modsuit_control/ui_act)
usr: GuiltyNeko/(Woodrow Brindle)
usr.loc: (Engineering Storage (131,117,4))
src: /datum/computer_file/program/m... (/datum/computer_file/program/maintenance/modsuit_control)
call stack:
/datum/computer_file/program/m... (/datum/computer_file/program/maintenance/modsuit_control): ui act("PC_exit", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/default (/datum/ui_state/default))
Woodrow Brindle (Chief Enginee... (/obj/item/modular_computer/pda/heads/ce): ui act("PC_exit", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/default (/datum/ui_state/default))
/datum/tgui (/datum/tgui): on act message("PC_exit", /list (/list), /datum/ui_state/default (/datum/ui_state/default))
/datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
/datum/tgui (/datum/tgui): on message("act/PC_exit", /list (/list), /list (/list))
/datum/tgui_window (/datum/tgui_window): on message("act/PC_exit", /list (/list), /list (/list))
tgui Topic(/list (/list))
GuiltyNeko (/client): Topic("type=act%2FPC_exit&payload=%7B...", /list (/list), null, null)
```

## How Does This Help ***Gameplay***?

I don't think this visibly affects much at all. Players were still seeing the correct screen.

## How Does This Help ***Roleplay***?

Nothing

## Proof of Testing

Tested locally with no runtimes. Nothing visibly changed.

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: A.C.M.O.
fix: Fix runtime in Modsuit Maintenance app.
/:cl:
