### PR TITLE
Ladder Controls QOL

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -33,7 +33,7 @@
 		context[SCREENTIP_CONTEXT_LMB] = "Climb up"
 	else if(down && !up)
 		context[SCREENTIP_CONTEXT_LMB] = "Climb down"
-	else if(!down && !up)
+	else if(down && up)
 		context[SCREENTIP_CONTEXT_LMB] = "Show travel options"
 
 	return !!context[SCREENTIP_CONTEXT_LMB]


### PR DESCRIPTION
## About The Pull Request

So, the left/right mouse bindings for ladders are completely asinine, and need to fucking stop, oh my god this is awful UX.

So, ladders now work like this;

You click the ladder, and if it can only go up or down, it will only take you up or down. If it can go in both directions, open the radial menu and let the user choose.

The radial menu is autoshown on climbing down to a ladder with the option to keep going in the direction you just went in.

## How Does This Help ***Gameplay***?

Ladders make sense now. Why the fuck let the user try doing something they can't do that should be obvious ICly to them?!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->


https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/eff83369-28d8-42ca-a65e-9d7fa97e4635
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Ladder controls now make sense.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
