### PR TITLE
Lobby Cam Fixes

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -203,7 +203,9 @@
 #define RENDER_PLANE_MASTER 9999
 //----------------------------------------------------
 
-#define LOBBY_BACKGROUND_LAYER 3
+// Lobby screen layers
+#define LOBBY_FADE_LAYER 3
+#define LOBBY_BACKGROUND_LAYER 3.01
 #define LOBBY_BUTTON_LAYER 4
 
 ///cinematics are "below" the splash screen

--- a/code/controllers/subsystem/lobby_eye_ss.dm
+++ b/code/controllers/subsystem/lobby_eye_ss.dm
@@ -58,9 +58,9 @@ SUBSYSTEM_DEF(lobby_eye)
 	if(!CONFIG_GET(flag/lobby_camera))
 		return
 
-	//fade out the logo and unlock eyes when 10 seconds until round start
+	//fade out the logo and unlock eyes when 20 seconds until round start
 	var/time_remaining = SSticker.GetTimeLeft()
-	if(time_remaining <= 20 SECONDS && SSticker.current_state == GAME_STATE_PREGAME)
+	if(time_remaining <= 20 SECONDS && time_remaining >= 0 && SSticker.current_state == GAME_STATE_PREGAME)
 		unlock_eyes()
 		return
 

--- a/code/modules/client/preferences/lobby_cam.dm
+++ b/code/modules/client/preferences/lobby_cam.dm
@@ -4,7 +4,7 @@
 	icon_state = "1"
 	screen_loc = "SOUTHWEST to NORTHEAST"
 	plane = SPLASHSCREEN_PLANE
-	layer = LOBBY_BACKGROUND_LAYER
+	layer = LOBBY_FADE_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/new_player_cam


### PR DESCRIPTION
## About The Pull Request

Makes the lobby cam fade not fade out the new player menu background, and also fixes the lobby cam to not disable itself when the round is delayed.

## How Does This Help ***Gameplay***?

Less time spent staring at default TG lobby art when the round is delayed.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/9fa75d8c-c463-4cd8-9529-8218160a5ec5)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/e5cbedce-15a1-46c9-a13d-770c70e043b2)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Made the lobby cam not disable itself on round delay.
fix: Fixed an overlap issue with the lobby cam and the new player menu background.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
