### PR TITLE
Re-add Throwing Changes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -191,6 +191,8 @@
 		power_throw++
 	if(neckgrab_throw)
 		power_throw++
+	do_attack_animation(target, no_effect = TRUE)
+	playsound(loc, 'sound/weapons/punchmiss.ogg', 50, TRUE, -1)
 	visible_message(span_danger("[src] throws [thrown_thing][power_throw ? " really hard!" : "."]"), \
 					span_danger("You throw [thrown_thing][power_throw ? " really hard!" : "."]"))
 	log_message("has thrown [thrown_thing] [power_throw ? "really hard" : ""]", LOG_ATTACK)


### PR DESCRIPTION
## About The Pull Request

Accidental revert during #269. Woops.

## How Does This Help ***Gameplay***?

Throwing behaves like it should.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->


https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/f2929833-7781-4209-bffd-111b9f5a9578


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

No CL.

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
