### PR TITLE
Red and Blue Cable Layers Now Actually Do Things

### DIFF
--- a/code/__DEFINES/power.dm
+++ b/code/__DEFINES/power.dm
@@ -1,8 +1,9 @@
 #define CABLE_LAYER_1 (1<<0)
+	#define CABLE_LAYER_1_NAME "Red Power Line"
 #define CABLE_LAYER_2 (1<<1)
+	#define CABLE_LAYER_2_NAME "Yellow Power Line"
 #define CABLE_LAYER_3 (1<<2)
-
-#define MACHINERY_LAYER_1 1
+	#define CABLE_LAYER_3_NAME "Blue Power Line"
 
 #define SOLAR_TRACK_OFF     0
 #define SOLAR_TRACK_TIMED   1
@@ -16,3 +17,18 @@
 GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
 
 GLOBAL_LIST_EMPTY(powernets)
+
+// Converts cable layer to its human readable name
+GLOBAL_LIST_INIT(cable_layer_to_name, list(
+	"[CABLE_LAYER_1]" = CABLE_LAYER_1_NAME,
+	"[CABLE_LAYER_2]" = CABLE_LAYER_2_NAME,
+	"[CABLE_LAYER_3]" = CABLE_LAYER_3_NAME
+))
+
+// Converts cable color name to its layer
+GLOBAL_LIST_INIT(cable_name_to_layer, list(
+	CABLE_LAYER_1_NAME = CABLE_LAYER_1,
+	CABLE_LAYER_2_NAME = CABLE_LAYER_2,
+	CABLE_LAYER_3_NAME = CABLE_LAYER_3
+))
+

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -61,9 +61,17 @@
 			balloon_alert(user, "need ten lengths of cable!")
 			return
 
+		var/terminal_cable_layer = CABLE_LAYER_1
+		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
+			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
+			if(isnull(choice))
+				return
+			terminal_cable_layer = GLOB.cable_name_to_layer[choice]
+
 		user.visible_message(span_notice("[user.name] adds cables to the APC frame."))
 		balloon_alert(user, "adding cables to the frame...")
 		playsound(loc, 'sound/items/deconstruct.ogg', 50, TRUE)
+
 		if(!do_after(user, 20, target = src))
 			return
 		if(installing_cable.get_amount() < 10 || !installing_cable)
@@ -77,7 +85,7 @@
 			return
 		installing_cable.use(10)
 		balloon_alert(user, "cables added to the frame")
-		make_terminal()
+		make_terminal(terminal_cable_layer)
 		terminal.connect_to_network()
 		return
 

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -61,12 +61,15 @@
 			balloon_alert(user, "need ten lengths of cable!")
 			return
 
-		var/terminal_cable_layer = CABLE_LAYER_1
 		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
-			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
-			if(isnull(choice))
-				return
-			terminal_cable_layer = GLOB.cable_name_to_layer[choice]
+			switch(terminal_cable_layer)
+				if(CABLE_LAYER_1)
+					terminal_cable_layer = CABLE_LAYER_2
+				if(CABLE_LAYER_2)
+					terminal_cable_layer = CABLE_LAYER_3
+				if(CABLE_LAYER_3)
+					terminal_cable_layer = CABLE_LAYER_1
+			balloon_alert(user, "using [lowertext(GLOB.cable_layer_to_name[terminal_cable_layer])] layer")
 
 		user.visible_message(span_notice("[user.name] adds cables to the APC frame."))
 		balloon_alert(user, "adding cables to the frame...")

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -56,6 +56,8 @@
 	var/aidisabled = FALSE
 	///Reference to our cable terminal
 	var/obj/machinery/power/terminal/terminal = null
+	/// The cable layer the terminal should use on construction.
+	var/terminal_cable_layer = CABLE_LAYER_2
 	///Amount of power used by the lighting channel
 	var/lastused_light = 0
 	///Amount of power used by the equipment channel
@@ -221,6 +223,8 @@
 	. = ..()
 	if(machine_stat & BROKEN)
 		return
+	if(!terminal && opened)
+		. += "Right-click with some cable coils to set the terminal layer."
 	if(opened)
 		if(has_electronics && terminal)
 			. += "The cover is [opened==APC_COVER_REMOVED?"removed":"open"] and the power cell is [ cell ? "installed" : "missing"]."

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -7,10 +7,11 @@
 	if(terminal)
 		terminal.connect_to_network()
 
-/obj/machinery/power/apc/proc/make_terminal()
+/obj/machinery/power/apc/proc/make_terminal(terminal_cable_layer)
 	// create a terminal object at the same position as original turf loc
 	// wires will attach to this
 	terminal = new/obj/machinery/power/terminal(loc)
+	terminal.cable_layer = cable_layer
 	terminal.setDir(dir)
 	terminal.master = src
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -662,7 +662,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	return
 
 /obj/structure/cable/multilayer/update_icon()
-	machinery_node?.alpha = machinery_layer & MACHINERY_LAYER_1 ? 255 : 0
+	machinery_node?.alpha = cable_layer & CABLE_LAYER_1 ? 255 : 0
 	cable_node_1?.alpha = cable_layer & CABLE_LAYER_1 ? 255 : 0
 	cable_node_2?.alpha = cable_layer & CABLE_LAYER_2 ? 255 : 0
 	cable_node_3?.alpha = cable_layer & CABLE_LAYER_3 ? 255 : 0

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -23,20 +23,17 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	var/linked_dirs = 0 //bitflag
 	var/node = FALSE //used for sprites display
 	var/cable_layer = CABLE_LAYER_2 //bitflag
-	var/machinery_layer = MACHINERY_LAYER_1 //bitflag
 	var/datum/powernet/powernet
 
 /obj/structure/cable/layer1
 	color = "red"
 	cable_layer = CABLE_LAYER_1
-	machinery_layer = null
 	layer = WIRE_LAYER - 0.01
 	icon_state = "l1-1-2-4-8-node"
 
 /obj/structure/cable/layer3
 	color = "blue"
 	cable_layer = CABLE_LAYER_3
-	machinery_layer = null
 	layer = WIRE_LAYER + 0.01
 	icon_state = "l4-1-2-4-8-node"
 
@@ -51,6 +48,11 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 		var/turf/turf_loc = loc
 		turf_loc.add_blueprints_preround(src)
 
+
+/obj/structure/cable/examine(mob/user)
+	. = ..()
+	if(isobserver(user))
+		. += get_power_info()
 
 /obj/structure/cable/proc/on_rat_eat(datum/source, mob/living/simple_animal/hostile/regalrat/king)
 	SIGNAL_HANDLER
@@ -155,13 +157,6 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	dir_string = "l[cable_layer]-[dir_string]"
 	icon_state = dir_string
 	return ..()
-
-
-/obj/structure/cable/examine(mob/user)
-	. = ..()
-	if(isobserver(user))
-		. += get_power_info()
-
 
 /obj/structure/cable/proc/handlecable(obj/item/W, mob/user, params)
 	var/turf/T = get_turf(src)
@@ -634,7 +629,6 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cable_bridge"
 	cable_layer = CABLE_LAYER_2
-	machinery_layer = MACHINERY_LAYER_1
 	layer = WIRE_LAYER - 0.02 //Below all cables Disabled layers can lay over hub
 	color = "white"
 	var/obj/effect/node/machinery_node
@@ -706,7 +700,6 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	. += span_notice("L1:[cable_layer & CABLE_LAYER_1 ? "Connect" : "Disconnect"].")
 	. += span_notice("L2:[cable_layer & CABLE_LAYER_2 ? "Connect" : "Disconnect"].")
 	. += span_notice("L3:[cable_layer & CABLE_LAYER_3 ? "Connect" : "Disconnect"].")
-	. += span_notice("M:[machinery_layer & MACHINERY_LAYER_1 ? "Connect" : "Disconnect"].")
 
 GLOBAL_LIST(hub_radial_layer_list)
 
@@ -720,8 +713,7 @@ GLOBAL_LIST(hub_radial_layer_list)
 		GLOB.hub_radial_layer_list = list(
 			"Layer 1" = image(icon = 'icons/hud/radial.dmi', icon_state = "coil-red"),
 			"Layer 2" = image(icon = 'icons/hud/radial.dmi', icon_state = "coil-yellow"),
-			"Layer 3" = image(icon = 'icons/hud/radial.dmi', icon_state = "coil-blue"),
-			"Machinery" = image(icon = 'icons/obj/power.dmi', icon_state = "smes")
+			"Layer 3" = image(icon = 'icons/hud/radial.dmi', icon_state = "coil-blue")
 			)
 
 	var/layer_result = show_radial_menu(user, src, GLOB.hub_radial_layer_list, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
@@ -738,9 +730,6 @@ GLOBAL_LIST(hub_radial_layer_list)
 		if("Layer 3")
 			CL = CABLE_LAYER_3
 			to_chat(user, span_warning("You toggle L3 connection."))
-		if("Machinery")
-			machinery_layer ^= MACHINERY_LAYER_1
-			to_chat(user, span_warning("You toggle machinery connection."))
 
 	cut_cable_from_powernet(FALSE)
 

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -11,6 +11,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "floodlight_c1"
 	density = TRUE
+
 	var/state = FLOODLIGHT_NEEDS_WIRES
 
 /obj/structure/floodlight_frame/attackby(obj/item/O, mob/user, params)
@@ -65,6 +66,8 @@
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
 	anchored = FALSE
 	light_power = 1.75
+	can_change_cable_layer = TRUE
+
 	/// List of power usage multipliers
 	var/list/light_setting_list = list(0, 5, 10, 15)
 	/// Constant coeff. for power usage
@@ -174,6 +177,12 @@
 			setting_text = "high power"
 	if(user)
 		to_chat(user, span_notice("You set [src] to [setting_text]."))
+
+/obj/machinery/power/floodlight/cable_layer_change_checks(mob/living/user, obj/item/tool)
+	if(anchored)
+		balloon_alert(user, "unanchor first!")
+		return FALSE
+	return TRUE
 
 /obj/machinery/power/floodlight/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/power/multiz.dm
+++ b/code/modules/power/multiz.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "cablerelay-on"
 	cable_layer = CABLE_LAYER_1|CABLE_LAYER_2|CABLE_LAYER_3
-	machinery_layer = null
 
 /obj/structure/cable/multilayer/multiz/get_cable_connections(powernetless_only)
 	. = ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -15,7 +15,10 @@
 	use_power = NO_POWER_USE
 	idle_power_usage = 0
 	active_power_usage = 0
-	var/machinery_layer = MACHINERY_LAYER_1 //cable layer to which the machine is connected
+	///Cable layer to which the machine is connected.
+	var/cable_layer = CABLE_LAYER_2
+	///Can the cable_layer be tweked with a multi tool
+	var/can_change_cable_layer = FALSE
 
 /obj/machinery/power/Initialize(mapload)
 	. = ..()
@@ -40,6 +43,34 @@
 //override this if the machine needs special functionality for making wire nodes appear, ie emitters, generators, etc.
 /obj/machinery/power/proc/should_have_node()
 	return FALSE
+
+/obj/machinery/power/examine(mob/user)
+	. = ..()
+	if(can_change_cable_layer)
+		if(!QDELETED(powernet))
+			. += span_notice("It's operating on the [lowertext(GLOB.cable_layer_to_name["[cable_layer]"])].")
+		else
+			. += span_warning("It's disconnected from the [lowertext(GLOB.cable_layer_to_name["[cable_layer]"])].")
+		. += span_notice("It's power line can be changed with a [EXAMINE_HINT("multitool")].")
+
+///does the required checks to see if this machinery layer can be changed
+/obj/machinery/power/proc/cable_layer_change_checks(mob/living/user, obj/item/tool)
+	return can_change_cable_layer
+
+/obj/machinery/power/multitool_act(mob/living/user, obj/item/tool)
+	if(!can_change_cable_layer || !cable_layer_change_checks(user, tool))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
+	if(isnull(choice))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	cable_layer = GLOB.cable_name_to_layer[choice]
+	balloon_alert(user, "now operating on the [choice]")
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/power/multitool_act_secondary(mob/living/user, obj/item/tool)
+	return multitool_act(user, tool)
 
 /obj/machinery/power/proc/add_avail(amount)
 	if(powernet)
@@ -193,7 +224,7 @@
 	if(!T || !istype(T))
 		return FALSE
 
-	var/obj/structure/cable/C = T.get_cable_node(machinery_layer) //check if we have a node cable on the machine turf, the first found is picked
+	var/obj/structure/cable/C = T.get_cable_node(cable_layer) //check if we have a node cable on the machine turf, the first found is picked
 	if(!C || !C.powernet)
 		var/obj/machinery/power/terminal/term = locate(/obj/machinery/power/terminal) in T
 		if(!term || !term.powernet)
@@ -418,11 +449,11 @@
 ///////////////////////////////////////////////
 
 // return a cable able connect to machinery on layer if there's one on the turf, null if there isn't one
-/turf/proc/get_cable_node(machinery_layer = MACHINERY_LAYER_1)
+/turf/proc/get_cable_node(cable_layer = CABLE_LAYER_1)
 	if(!can_have_cabling())
 		return null
 	for(var/obj/structure/cable/C in src)
-		if(C.machinery_layer & machinery_layer)
+		if(C.cable_layer & cable_layer)
 			C.update_appearance()
 			return C
 	return null

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -11,6 +11,7 @@
 	circuit = /obj/item/circuitboard/machine/emitter
 
 	use_power = NO_POWER_USE
+	can_change_cable_layer = TRUE
 
 	/// The icon state used by the emitter when it's on.
 	var/icon_state_on = "emitter_+a"
@@ -75,6 +76,12 @@
 /obj/machinery/power/emitter/welded/Initialize(mapload)
 	welded = TRUE
 	. = ..()
+
+/obj/machinery/power/emitter/cable_layer_change_checks(mob/living/user, obj/item/tool)
+	if(welded)
+		balloon_alert(user, "unweld first!")
+		return FALSE
+	return TRUE
 
 /obj/machinery/power/emitter/set_anchored(anchorvalue)
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -21,6 +21,7 @@
 	density = TRUE
 	use_power = NO_POWER_USE
 	circuit = /obj/item/circuitboard/machine/smes
+	can_change_cable_layer = TRUE
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 0 // actual charge
@@ -79,6 +80,12 @@
 /obj/machinery/power/smes/should_have_node()
 	return TRUE
 
+/obj/machinery/power/smes/cable_layer_change_checks(mob/living/user, obj/item/tool)
+	if(!QDELETED(terminal))
+		balloon_alert(user, "cut the terminal first!")
+		return FALSE
+	return TRUE
+
 /obj/machinery/power/smes/attackby(obj/item/I, mob/user, params)
 	//opening using screwdriver
 	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), I))
@@ -127,6 +134,13 @@
 			to_chat(user, span_warning("You need more wires!"))
 			return
 
+		var/terminal_cable_layer = CABLE_LAYER_1
+		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
+			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
+			if(isnull(choice))
+				return
+			terminal_cable_layer = GLOB.cable_name_to_layer[choice]
+
 		to_chat(user, span_notice("You start building the power terminal..."))
 		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 
@@ -143,7 +157,7 @@
 					span_notice("You build the power terminal."))
 
 				//build the terminal and link it to the network
-				make_terminal(T)
+				make_terminal(T, terminal_cable_layer)
 				terminal.connect_to_network()
 				connect_to_network()
 		return
@@ -191,8 +205,9 @@
 
 // create a terminal object pointing towards the SMES
 // wires will attach to this
-/obj/machinery/power/smes/proc/make_terminal(turf/T)
+/obj/machinery/power/smes/proc/make_terminal(turf/T, terminal_cable_layer)
 	terminal = new/obj/machinery/power/terminal(T)
+	terminal.cable_layer = terminal_cable_layer
 	terminal.setDir(get_dir(T,src))
 	terminal.master = src
 	set_machine_stat(machine_stat & ~BROKEN)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -39,7 +39,6 @@
 	var/output_used = 0 // amount of power actually outputted. may be less than output_level if the powernet returns excess power
 
 	var/obj/machinery/power/terminal/terminal = null
-
 	/// The cable layer the terminal should use on construction.
 	var/terminal_cable_layer = CABLE_LAYER_2
 
@@ -47,6 +46,8 @@
 	. = ..()
 	if(!terminal)
 		. += span_warning("This SMES has no power terminal!")
+		if(panel_open)
+			. += "Right-click with some cable coils to set the terminal layer."
 
 /obj/machinery/power/smes/Initialize(mapload)
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -40,6 +40,9 @@
 
 	var/obj/machinery/power/terminal/terminal = null
 
+	/// The cable layer the terminal should use on construction.
+	var/terminal_cable_layer = CABLE_LAYER_2
+
 /obj/machinery/power/smes/examine(user)
 	. = ..()
 	if(!terminal)
@@ -134,12 +137,16 @@
 			to_chat(user, span_warning("You need more wires!"))
 			return
 
-		var/terminal_cable_layer = CABLE_LAYER_1
 		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
-			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
-			if(isnull(choice))
-				return
-			terminal_cable_layer = GLOB.cable_name_to_layer[choice]
+			switch(terminal_cable_layer)
+				if(CABLE_LAYER_1)
+					terminal_cable_layer = CABLE_LAYER_2
+				if(CABLE_LAYER_2)
+					terminal_cable_layer = CABLE_LAYER_3
+				if(CABLE_LAYER_3)
+					terminal_cable_layer = CABLE_LAYER_1
+			balloon_alert(user, "using [lowertext(GLOB.cable_layer_to_name[terminal_cable_layer])] layer")
+			return
 
 		to_chat(user, span_notice("You start building the power terminal..."))
 		playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -22,6 +22,13 @@
 		master = null
 	return ..()
 
+/obj/machinery/power/terminal/examine(mob/user)
+	. = ..()
+	if(!QDELETED(powernet))
+		. += span_notice("It's operating on the [lowertext(GLOB.cable_layer_to_name["[cable_layer]"])].")
+	else
+		. += span_warning("It's disconnected from the [lowertext(GLOB.cable_layer_to_name["[cable_layer]"])].")
+
 /obj/machinery/power/terminal/should_have_node()
 	return TRUE
 
@@ -37,7 +44,6 @@
 	. = FALSE
 	if(panel_open)
 		. = TRUE
-
 
 /obj/machinery/power/terminal/proc/dismantle(mob/living/user, obj/item/I)
 	if(isturf(loc))

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -13,6 +13,7 @@
 	can_buckle = TRUE
 	buckle_lying = 0
 	buckle_requires_restraints = TRUE
+	can_change_cable_layer = TRUE
 
 	circuit = /obj/item/circuitboard/machine/tesla_coil
 
@@ -37,6 +38,12 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/Initialize(mapload)
 	. = ..()
 	wires = new /datum/wires/tesla_coil(src)
+
+/obj/machinery/power/energy_accumulator/tesla_coil/cable_layer_change_checks(mob/living/user, obj/item/tool)
+	if(anchored)
+		balloon_alert(user, "unanchor first!")
+		return FALSE
+	return TRUE
 
 /obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
 	. = ..()

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -242,6 +242,7 @@
 	desc = "The middle part of a turbine generator, contains the rotor and the main computer."
 	icon = 'icons/obj/turbine/turbine.dmi'
 	icon_state = "core_rotor"
+	can_change_cable_layer = TRUE
 
 	circuit = /obj/item/circuitboard/machine/turbine_rotor
 
@@ -333,12 +334,32 @@
 		was_complete = TRUE
 	deactivate_parts()
 
+/obj/machinery/power/turbine/core_rotor/examine(mob/user)
+	. = ..()
+	if(!panel_open)
+		. += span_notice("[EXAMINE_HINT("screw")] open its panel to change cable layer.")
+
+/obj/machinery/power/turbine/core_rotor/cable_layer_change_checks(mob/living/user, obj/item/tool)
+	if(!panel_open)
+		balloon_alert(user, "open panel first!")
+		return FALSE
+	return TRUE
+
 /obj/machinery/power/turbine/core_rotor/multitool_act(mob/living/user, obj/item/tool)
+	//allow cable layer changing
+	if(panel_open)
+		return ..()
+
 	if(!all_parts_connected && activate_parts(user))
 		balloon_alert(user, "all parts are linked")
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/power/turbine/core_rotor/multitool_act_secondary(mob/living/user, obj/item/tool)
+	//allow cable layer changing
+	if(panel_open)
+		return ..()
+
+	//works same as regular left click
 	if(!all_parts_connected)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 	var/obj/item/multitool/multitool = tool


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/76075

## About The Pull Request

Machines that require a cable underneath it to operate like Tesla, SMES,
Emitter & Turbine now look for the `cable_layer` (red, yellow, blue
default being yellow) to operate on and not `machine_layer`(that var is
removed). `machine_layer` & `cable layer` served the same purpose so i
removed `machine_ layer` var and made it just look for the cable layer
to operate on to reduce redundancy.

The following machine's can have their cable layer changed with a
multitool when in the specified state
1. Emitter when it's not welded
2. Tesla Coil when it's not wrenched
3. SMES when it does not have a terminal attached
3.1 Terminal of the SMES cable layer can also be changed with Right
Click during installation
4. APC terminal cable layer can also be changed with Right Click during
installation
5. Turbine rotor when its panel is open

![POWER](https://github.com/tgstation/tgstation/assets/110812394/21827905-0a46-43de-8626-489e773c370a)
Here all 3 SMES were on 3 separate layers of cable but they were all
joined by a single multi z layer hub cable summing up all their
contribution's even though they were on different cable layers.

## How Does This Help ***Gameplay***?
It makes sense that a machine should only look for what cable layer it
should operate on and adding another layer called machine layer was just
redundant. Also cable layers blue & red which could not be used by
machines are now usable

## Testing

<details>
<summary>Images</summary>

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/68b396ff-27cf-49d8-9cd2-9695b3f94a7b)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/16470ff7-1e85-4e77-8121-953c5153f0a4)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/76b590eb-23c8-46c0-a08e-0dcd67f47322)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/451db9d5-655f-4f83-9934-41d4b4d2c0e3)
</details>

## Changelog
🆑
fix: Cable layers 1 & 3 can now be used by machine's like emitters,
SMES, tesla coil & turbine.
fix: Terminals (SMES & APC) can operate on different cable layers by
installing them with right click.
/🆑
