### PR TITLE
Make harddel lookups exist on unit tests by default. Don't know why it isn't like this already.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 ## Artea Station (TG Fork)
-###### <sup>With many opinions</sup>
 
 **This repository and it's server is wholly unsuitable for under 18s. You have been warned.**
 
 [![CI Suite](https://github.com/Nosha-Industries/Nosha-Industries-Server/actions/workflows/ci_suite.yml/badge.svg)](https://github.com/Nosha-Industries/Nosha-Industries-Server/actions/workflows/ci_suite.yml)
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/Nosha-Industries/Nosha-Industries-Server.svg)](https://isitmaintained.com/project/Nosha-Industries/Nosha-Industries-Server "Percentage of issues still open")
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/Nosha-Industries/Nosha-Industries-Server.svg)](https://isitmaintained.com/project/Nosha-Industries/Nosha-Industries-Server "Average time to resolve an issue")
 ![Coverage](https://img.shields.io/codecov/c/github/Nosha-Industries/Nosha-Industries-Server)
 
 [![resentment](https://forthebadge.com/images/badges/built-with-resentment.svg)](https://www.monkeyuser.com/assets/images/2019/131-bug-free.png) [![resentment](https://forthebadge.com/images/badges/contains-technical-debt.svg)](https://user-images.githubusercontent.com/8171642/50290880-ffef5500-043a-11e9-8270-a2e5b697c86c.png) [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
 
 * **Git / GitHub cheatsheet:** https://www.notion.so/Git-GitHub-61bc81766b2e4c7d9a346db3078ce833
-* **Website:** https://artea-station.net
+* **Website:** N/A
 * **Discord:** https://discord.gg/BrwHEt8Hdc
-* **Code:** https://github.com/Artea-Station/Artea-Station-Server
-* **Wiki:** https://artea-station.net/wiki
+* **Code:** https://github.com/Nosha-Industries/Nosha-Industries-Server
+* **Wiki:** https://tgstation13.org/wiki/Main_Page
 * **Codedocs:** N/A
 * **Coderbus Discord:** https://discord.gg/Vh8TJp9
 
-This is Artea's fork of TG created in byond.
+This is Nosha Industry's fork of TG created in byond.
 
 Unlisted community for now until the requisite systems for a fun and playable round that isn't just vanilla TG are implemented.
 
@@ -33,9 +34,11 @@ Mappers: Make sure to spawn your map in and ensure it has no warnings about dupl
 Coders: Just make sure your stuff works as intended, and doesn't drop runtimes.
 
 ## DOWNLOADING
-[Setting up a dev environment](https://hackmd.io/uCxdr1EjTwOFc6E7EMD6Qw)
+[Downloading](.github/guides/DOWNLOADING.md)
 
-[Running a server](.github/guides/RUNNING_A_SERVER.md)
+[Running on the server](.github/guides/RUNNING_A_SERVER.md)
+
+[Maps and Away Missions](.github/guides/MAPS_AND_AWAY_MISSIONS.md)
 
 ## :exclamation: How to compile :exclamation:
 
@@ -50,10 +53,10 @@ Find `BUILD.bat` or `RUN_SERVER.bat` here in the root folder of this project, an
 ## Contributors
 [Guides for Contributors](.github/CONTRIBUTING.md)
 
-[/tg/station HACKMD account](https://hackmd.io/@tgstation) - TG design documentation here. Do keep in mind that we don't follow these, but there are some good code insights. One of particular note for featurecoders is the one on how to write a [good design doc](https://hackmd.io/@tgstation/BkzmU9EyK).
+[/tg/station HACKMD account](https://hackmd.io/@tgstation) - TG design documentation here
 
 **Interested in some starting lore?**  
-We have some basic lore for a couple of the species, as well as an overarching story. Message Kepteyn on discord if you're interested in writing compact, concise lore! Extra fluff may come later.
+Unfortunately, we do not have any at this time. Message RimiNosha on discord if you're interested in writing compact, concise lore! Extra fluff may come later.
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
 ## Artea Station (TG Fork)
+###### <sup>With many opinions</sup>
 
 **This repository and it's server is wholly unsuitable for under 18s. You have been warned.**
 
 [![CI Suite](https://github.com/Nosha-Industries/Nosha-Industries-Server/actions/workflows/ci_suite.yml/badge.svg)](https://github.com/Nosha-Industries/Nosha-Industries-Server/actions/workflows/ci_suite.yml)
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/Nosha-Industries/Nosha-Industries-Server.svg)](https://isitmaintained.com/project/Nosha-Industries/Nosha-Industries-Server "Percentage of issues still open")
-[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/Nosha-Industries/Nosha-Industries-Server.svg)](https://isitmaintained.com/project/Nosha-Industries/Nosha-Industries-Server "Average time to resolve an issue")
 ![Coverage](https://img.shields.io/codecov/c/github/Nosha-Industries/Nosha-Industries-Server)
 
 [![resentment](https://forthebadge.com/images/badges/built-with-resentment.svg)](https://www.monkeyuser.com/assets/images/2019/131-bug-free.png) [![resentment](https://forthebadge.com/images/badges/contains-technical-debt.svg)](https://user-images.githubusercontent.com/8171642/50290880-ffef5500-043a-11e9-8270-a2e5b697c86c.png) [![forinfinityandbyond](https://user-images.githubusercontent.com/5211576/29499758-4efff304-85e6-11e7-8267-62919c3688a9.gif)](https://www.reddit.com/r/SS13/comments/5oplxp/what_is_the_main_problem_with_byond_as_an_engine/dclbu1a)
 
 * **Git / GitHub cheatsheet:** https://www.notion.so/Git-GitHub-61bc81766b2e4c7d9a346db3078ce833
-* **Website:** N/A
+* **Website:** https://artea-station.net
 * **Discord:** https://discord.gg/BrwHEt8Hdc
-* **Code:** https://github.com/Nosha-Industries/Nosha-Industries-Server
-* **Wiki:** https://tgstation13.org/wiki/Main_Page
+* **Code:** https://github.com/Artea-Station/Artea-Station-Server
+* **Wiki:** https://artea-station.net/wiki
 * **Codedocs:** N/A
 * **Coderbus Discord:** https://discord.gg/Vh8TJp9
 
-This is Nosha Industry's fork of TG created in byond.
+This is Artea's fork of TG created in byond.
 
 Unlisted community for now until the requisite systems for a fun and playable round that isn't just vanilla TG are implemented.
 
@@ -34,11 +33,9 @@ Mappers: Make sure to spawn your map in and ensure it has no warnings about dupl
 Coders: Just make sure your stuff works as intended, and doesn't drop runtimes.
 
 ## DOWNLOADING
-[Downloading](.github/guides/DOWNLOADING.md)
+[Setting up a dev environment](https://hackmd.io/uCxdr1EjTwOFc6E7EMD6Qw)
 
-[Running on the server](.github/guides/RUNNING_A_SERVER.md)
-
-[Maps and Away Missions](.github/guides/MAPS_AND_AWAY_MISSIONS.md)
+[Running a server](.github/guides/RUNNING_A_SERVER.md)
 
 ## :exclamation: How to compile :exclamation:
 
@@ -53,10 +50,10 @@ Find `BUILD.bat` or `RUN_SERVER.bat` here in the root folder of this project, an
 ## Contributors
 [Guides for Contributors](.github/CONTRIBUTING.md)
 
-[/tg/station HACKMD account](https://hackmd.io/@tgstation) - TG design documentation here
+[/tg/station HACKMD account](https://hackmd.io/@tgstation) - TG design documentation here. Do keep in mind that we don't follow these, but there are some good code insights. One of particular note for featurecoders is the one on how to write a [good design doc](https://hackmd.io/@tgstation/BkzmU9EyK).
 
 **Interested in some starting lore?**  
-Unfortunately, we do not have any at this time. Message RimiNosha on discord if you're interested in writing compact, concise lore! Extra fluff may come later.
+We have some basic lore for a couple of the species, as well as an overarching story. Message Kepteyn on discord if you're interested in writing compact, concise lore! Extra fluff may come later.
 
 ## LICENSE
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -19,8 +19,13 @@
 ///Slightly slower, higher in memory. Just not optimal
 #define REFERENCE_TRACKING_DEBUG
 
-///Run a lookup on things hard deleting by default.
+///Run a lookup on things hard deleting by default when unit tests are running.
+#ifdef UNIT_TESTS
 #define GC_FAILURE_HARD_LOOKUP
+#endif //ifdef UNIT_TESTS
+
+//Uncomment to use this outside of unit tests.
+//#define GC_FAILURE_HARD_LOOKUP
 #ifdef GC_FAILURE_HARD_LOOKUP
 ///Don't stop when searching, go till you're totally done
 #define FIND_REF_NO_CHECK_TICK

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -20,7 +20,7 @@
 #define REFERENCE_TRACKING_DEBUG
 
 ///Run a lookup on things hard deleting by default.
-//#define GC_FAILURE_HARD_LOOKUP
+#define GC_FAILURE_HARD_LOOKUP
 #ifdef GC_FAILURE_HARD_LOOKUP
 ///Don't stop when searching, go till you're totally done
 #define FIND_REF_NO_CHECK_TICK


### PR DESCRIPTION
Quick PR that makes #TESTING do ref tracking by default. That's like 90% reason to use that define anyways.

Merging as soon as CI decides this is fine.