### PR TITLE
[Port] Slightly less dumb addiction timers

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -119,11 +119,11 @@
 #define MAX_ADDICTION_POINTS 1000
 
 ///Addiction start/ends
-#define WITHDRAWAL_STAGE1_START_CYCLE 61
-#define WITHDRAWAL_STAGE1_END_CYCLE 120
-#define WITHDRAWAL_STAGE2_START_CYCLE 121
-#define WITHDRAWAL_STAGE2_END_CYCLE 180
-#define WITHDRAWAL_STAGE3_START_CYCLE 181
+#define WITHDRAWAL_STAGE1_START_CYCLE 600 //10 minutes
+#define WITHDRAWAL_STAGE1_END_CYCLE 1200
+#define WITHDRAWAL_STAGE2_START_CYCLE 1201 // 20 minutes
+#define WITHDRAWAL_STAGE2_END_CYCLE 2400
+#define WITHDRAWAL_STAGE3_START_CYCLE 2400 //40 minutes
 
 ///reagent tags - used to look up reagents for specific effects. Feel free to add to but comment it
 /// This reagent does brute effects (BOTH damaging and healing)


### PR DESCRIPTION
## About The Pull Request

Honey its time for your monthly DD port.
- https://github.com/DaedalusDock/daedalusdock/pull/468

## How Does This Help ***Gameplay***?

TG addiction timers by default are really dumb and this will make it less dumb.

## How Does This Help ***Roleplay***?

Something about immersion

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Tested on a local server and seems to work as intended.

</details>

## Changelog

:cl:
balance: Addiction phases changed to 10/20/40 minutes from 1/2/3 minutes.
/:cl: