### PR TITLE
Removes Interaction Animations From Some Structures

### DIFF
--- a/code/game/objects/structures/fans.dm
+++ b/code/game/objects/structures/fans.dm
@@ -9,6 +9,7 @@
 	var/buildstacktype = /obj/item/stack/sheet/iron
 	var/buildstackamount = 5
 	can_atmos_pass = ATMOS_PASS_NO
+	interaction_flags_atom = NONE
 
 /obj/structure/fans/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -9,6 +9,7 @@
 	anchored = TRUE
 	density = TRUE
 	max_integrity = 200
+	interaction_flags_atom = NONE
 	var/state = GIRDER_NORMAL
 	var/girderpasschance = GIRDER_PASSCHANCE_NORMAL // percentage chance that a projectile passes through the girder.
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -16,6 +16,7 @@
 	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_LOW_WALL, SMOOTH_GROUP_AIRLOCK, SMOOTH_GROUP_SHUTTERS_BLASTDOORS)
 	armor = list(MELEE = 20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
 	greyscale_config = /datum/greyscale_config/low_wall
+	interaction_flags_atom = NONE
 	/// Material used in construction
 	var/plating_material = /datum/material/iron
 	/// Paint color of our wall

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -10,6 +10,7 @@
 	/// armor more or less consistent with grille. max_integrity about one time and a half that of a grille.
 	armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 100, BOMB = 10, BIO = 0, FIRE = 0, ACID = 0)
 	max_integrity = 75
+	interaction_flags_atom = NONE
 
 	var/climbable = TRUE
 	///Initial direction of the railing.

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -22,6 +22,7 @@
 	anchored = TRUE
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	layer = TABLE_LAYER
+	interaction_flags_atom = NONE
 	var/frame = /obj/structure/table_frame
 	var/framestack = /obj/item/stack/rods
 	var/buildstack = /obj/item/stack/sheet/iron


### PR DESCRIPTION
## About The Pull Request

Removes it from fans, girders, low walls, railings and tables. These are not interactable, so it makes no sense for them to have the animations.

## How Does This Help ***Gameplay***?

Less animations shown for folk's (mis)clicks where it provides no relevant information.

## Proof of Testing

Oh look, it has no animation!
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/87cff185-8b5e-4ef5-944a-abf8ef0c412c)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Removed pointless interact animations from fans, girders, low walls, railings and tables.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
