### PR TITLE
Removes "Syndicate" From Many Tot Items

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -3,9 +3,9 @@
 
 /obj/machinery/syndicatebomb
 	icon = 'icons/obj/assemblies/assemblies.dmi'
-	name = "syndicate bomb"
+	name = "reinforced bomb"
 	icon_state = "syndicate-bomb"
-	desc = "A large and menacing device. Can be bolted down with a wrench."
+	desc = "A large and menacing device. Can be bolted down with a wrench. Looks very tough."
 
 	anchored = FALSE
 	density = FALSE

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -683,8 +683,8 @@
 	. = ..()
 
 /obj/item/shockpaddles/syndicate
-	name = "syndicate defibrillator paddles"
-	desc = "A pair of paddles used to revive deceased operatives. They possess both the ability to penetrate armor and to deliver powerful or disabling shocks offensively."
+	name = "combat defibrillator paddles"
+	desc = "A pair of paddles used to revive deceased individuals. This particular type can penetrate armor and deliver powerful or disabling shocks offensively."
 	combat = TRUE
 	icon = 'icons/obj/medical/defib.dmi'
 	icon_state = "syndiepaddles0"
@@ -692,13 +692,12 @@
 	base_icon_state = "syndiepaddles"
 
 /obj/item/shockpaddles/syndicate/nanotrasen
-	name = "elite nanotrasen defibrillator paddles"
-	desc = "A pair of paddles used to revive deceased ERT members. They possess both the ability to penetrate armor and to deliver powerful or disabling shocks offensively."
 	icon_state = "ntpaddles0"
 	inhand_icon_state = "ntpaddles0"
 	base_icon_state = "ntpaddles"
 
 /obj/item/shockpaddles/syndicate/cyborg
+	name = "cyborg combat defibrillator paddles"
 	req_defib = FALSE
 
 #undef HALFWAYCRITDEATH

--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -1,6 +1,6 @@
 /obj/item/grenade/syndieminibomb
-	desc = "A syndicate manufactured explosive used to sow destruction and chaos."
-	name = "syndicate minibomb"
+	name = "minibomb"
+	desc = "An explosive used to sow destruction and chaos. Favoured by saboteurs for their versatility."
 	icon = 'icons/obj/weapons/grenade.dmi'
 	icon_state = "syndicate"
 	inhand_icon_state = "flashbang"
@@ -19,7 +19,7 @@
 	qdel(src)
 
 /obj/item/grenade/syndieminibomb/concussion
-	name = "HE Grenade"
+	name = "HE grenade"
 	desc = "A compact shrapnel grenade meant to devastate nearby organisms and cause some damage in the process. Pull pin and throw opposite direction."
 	icon_state = "concussion"
 	ex_heavy = 2

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -100,7 +100,7 @@
 	),src)
 
 /obj/item/storage/belt/holster/chameleon
-	name = "syndicate holster"
+	name = "chameleon holster"
 	desc = "A hip holster that uses chameleon technology to disguise itself, due to the added chameleon tech, it cannot be mounted onto armor."
 	icon_state = "syndicate_holster"
 	inhand_icon_state = "syndicate_holster"

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -117,8 +117,8 @@
 	return COMPONENT_NO_DEFAULT_MESSAGE
 
 /obj/item/crowbar/power/syndicate
-	name = "Syndicate jaws of life"
-	desc = "A pocket sized re-engineered copy of Nanotrasen's standard jaws of life. Can be used to force open airlocks in its crowbar configuration."
+	name = "advanced jaws of life"
+	desc = "A pocket sized re-engineered copy of the standard jaws of life that are significantly more powerful. Can be used to force open airlocks in its crowbar configuration."
 	icon_state = "jaws_syndie"
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -223,8 +223,8 @@ LINEN BINS
 	dream_messages = list("a unique ID", "authority", "artillery", "an ending")
 
 /obj/item/bedsheet/syndie
-	name = "syndicate bedsheet"
-	desc = "It has a syndicate emblem and it has an aura of evil."
+	name = "blood red bedsheet"
+	desc = "It has an unfamiliar emblem, but it has a strange aura of evil."
 	icon_state = "sheetsyndie"
 	inhand_icon_state = "sheetsyndie"
 	dream_messages = list("a green disc", "a red crystal", "a glowing blade", "a wire-covered ID")

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -43,12 +43,12 @@
 
 /datum/export/gear/space/syndiehelmet
 	cost = CARGO_CRATE_VALUE * 0.3
-	unit_name = "Syndicate space helmet"
+	unit_name = "crimson space helmet"
 	export_types = list(/obj/item/clothing/head/helmet/space/syndicate)
 
 /datum/export/gear/space/syndiesuit
 	cost = CARGO_CRATE_VALUE * 0.6
-	unit_name = "Syndicate space suit"
+	unit_name = "crimson space suit"
 	export_types = list(/obj/item/clothing/suit/space/syndicate)
 
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -149,8 +149,8 @@
 	flags_cover = MASKCOVERSEYES
 
 /obj/item/clothing/mask/gas/syndicate
-	name = "syndicate mask"
-	desc = "A close-fitting tactical mask that can be connected to an air supply."
+	name = "compact mask"
+	desc = "A close-fitting tactical mask that can be connected to an air supply. Folds to be smaller than a normal gas mask."
 	icon_state = "syndicate"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	strip_delay = 60

--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -109,7 +109,7 @@
 	theme = /datum/mod_theme/mining
 
 /obj/item/clothing/suit/space/hardsuit/syndi
-	theme = /datum/mod_theme/syndicate
+	theme = /datum/mod_theme/crimson
 
 #define START_STEP "start"
 #define CORE_STEP "core"

--- a/code/modules/mod/mod_paint.dm
+++ b/code/modules/mod/mod_paint.dm
@@ -191,4 +191,4 @@
 
 /obj/item/mod/skin_applier/honkerative
 	skin = "honkerative"
-	compatible_theme = /datum/mod_theme/syndicate
+	compatible_theme = /datum/mod_theme/crimson

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -792,14 +792,14 @@
 	)
 
 /datum/mod_theme/syndicate
-	name = "syndicate"
-	desc = "A suit designed by Gorlex Marauders, offering armor ruled illegal in most of Spinward Stellar."
+	name = "crimson"
+	desc = "A suit designed by an unknown organisation, offering armor ruled illegal in most of the empire, outside of military use."
 	extended_desc = "An advanced combat suit adorned in a sinister crimson red color scheme, produced and manufactured \
 		for special mercenary operations. The build is a streamlined layering consisting of shaped Plasteel, \
 		and composite ceramic, while the under suit is lined with a lightweight Kevlar and durathread hybrid weave \
 		to provide ample protection to the user where the plating doesn't, with an illegal onboard electric powered \
 		ablative shield module to provide resistance against conventional energy firearms. \
-		A small tag hangs off of it reading; 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
+		A small tag hangs off of it reading; 'Property of', the name being illegible. \
 		All rights reserved, tampering with suit will void warranty."
 	default_skin = "syndicate"
 	armor = list(MELEE = 15, BULLET = 20, LASER = 15, ENERGY = 15, BOMB = 35, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -146,7 +146,7 @@
 	)
 
 /obj/item/mod/control/pre_equipped/traitor
-	theme = /datum/mod_theme/syndicate
+	theme = /datum/mod_theme/crimson
 	applied_cell = /obj/item/stock_parts/cell/super
 	initial_modules = list(
 		/obj/item/mod/module/storage/syndicate,
@@ -171,7 +171,7 @@
 	)
 
 /obj/item/mod/control/pre_equipped/nuclear
-	theme = /datum/mod_theme/syndicate
+	theme = /datum/mod_theme/crimson
 	applied_cell = /obj/item/stock_parts/cell/hyper
 	req_access = list(ACCESS_SYNDICATE)
 	initial_modules = list(
@@ -381,7 +381,7 @@
 /obj/item/mod/control/pre_equipped/empty
 
 /obj/item/mod/control/pre_equipped/empty/syndicate
-	theme = /datum/mod_theme/syndicate
+	theme = /datum/mod_theme/crimson
 
 /obj/item/mod/control/pre_equipped/empty/syndicate/honkerative
 	applied_skin = "honkerative"

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -95,7 +95,7 @@
 	dye_color = DYE_CENTCOM
 
 /obj/item/stamp/syndicate
-	name = "Syndicate rubber stamp"
+	name = "red rubber stamp"
 	icon_state = "stamp-syndicate"
 	dye_color = DYE_SYNDICATE
 

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -123,9 +123,6 @@
 	list_reagents = list(/datum/reagent/consumable/frostoil = 30)
 
 /obj/item/reagent_containers/cup/bottle/traitor
-	name = "syndicate bottle"
-	desc = "A small bottle. Contains a random nasty chemical."
-	icon = 'icons/obj/medical/chemical.dmi'
 	var/extra_reagent = null
 
 /obj/item/reagent_containers/cup/bottle/traitor/Initialize(mapload)

--- a/code/modules/uplink/uplink_items/suits.dm
+++ b/code/modules/uplink/uplink_items/suits.dm
@@ -19,7 +19,7 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/suits/space_suit
-	name = "Syndicate Space Suit"
+	name = "Crimson Space Suit"
 	desc = "This red and black Syndicate space suit is less encumbering than Nanotrasen variants, \
 			fits inside bags, and has a weapon slot. Nanotrasen crew members are trained to report red space suit \
 			sightings, however."
@@ -29,7 +29,7 @@
 // Low progression cost
 
 /datum/uplink_item/suits/modsuit
-	name = "Syndicate MODsuit"
+	name = "Crimson MODsuit"
 	desc = "The feared MODsuit of a Syndicate agent. Features armoring and a set of inbuilt modules."
 	item = /obj/item/mod/control/pre_equipped/traitor
 	cost = 8


### PR DESCRIPTION
## About The Pull Request

Syndicate is ded in this universe, let's not.

Jaws of life and the defib have been renamed to advanced jaws and combat defib respectively, everything else just uses crimson.

Descriptions have been updated to match.

## How Does This Help ***Gameplay***?

Folk no longer can go "oh look, that item says syndie, VALID!!1111".

## How Does This Help ***Roleplay***?

It makes it easier to point out that syndies are not going to be a faction down the line. That's taken up by Darkof.

## Proof of Testing

These are simple string changes, and it compiles just fine.

## Changelog

:cl:
spellcheck: "Syndicate" is no longer as prevalent in saboteur item names.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
