### PR TITLE
[Port] Browser datums no longer force HTML 4.1

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -70,7 +70,8 @@
 	for (file in scripts)
 		head_content += "<script type='text/javascript' src='[SSassets.transport.get_asset_url(file)]'></script>"
 
-	return {"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+	return {"
+<!DOCTYPE html>
 <html>
 	<head>
 		<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>


### PR DESCRIPTION
## About The Pull Request

Ported from DD: -https://github.com/DaedalusDock/daedalusdock/pull/549

## How Does This Help ***Gameplay***?

No impact on Gaming.

## How Does This Help ***Roleplay***?

No impact on RP

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

### No runtimes other than the usual one.

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/4be08a8c-5739-4b07-9b34-11c5c4959f38)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/a91c1879-a968-44ad-8a07-5abad35ca823)



</details>

## Changelog
:cl:
code: Browser datums no longer force HTML 4.1
/:cl: