### PR TITLE
Fixes roundstart atmos diffs on Waystation.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -33,7 +33,7 @@
 /obj/structure/marker_beacon/olive,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/ruin/space)
+/area/template_noop)
 "aO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/cable,
@@ -415,7 +415,7 @@
 "hp" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/ruin/space)
+/area/template_noop)
 "hq" = (
 /obj/effect/turf_decal/stripes/red/end,
 /obj/structure/chair/comfy/shuttle{
@@ -662,8 +662,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/waystation/dorms)
 "lt" = (
-/turf/open/floor/catwalk_floor,
-/area/ruin/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/template_noop)
 "lx" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1


### PR DESCRIPTION
## About The Pull Request

Simple fix, the floors used in space weren't airless so heehoo funny roundstart AT diffs happened. This is fixed now.


### This is bad, This PR fixes this.
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/ea5e08be-eade-4f08-80c4-bd6c97bd01ee)


## How Does This Help ***Gameplay***?

Minimal impact on Gameplay.

## How Does This Help ***Roleplay***?

Minimal Impact on RP.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/bba4ebda-9bc7-400a-ad1d-6bcbf863c046)

</details>

## Changelog
:cl:
fix: Fixed roundstart atmos diffs on waystation space ruin.
/:cl: