### PR TITLE
Severely Nerf Goliaths, Remove Natural Bileworms, Fix Volcanic Planet Baseturf

### DIFF
--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -14,7 +14,6 @@
 		/mob/living/simple_animal/hostile/asteroid/goldgrub = 10,
 		/mob/living/simple_animal/hostile/asteroid/lobstrosity/lava = 20,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
-		/mob/living/basic/bileworm = 20,
 	)
 	weighted_flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2, /obj/structure/flora/ash/seraka = 2)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -17,16 +17,15 @@
 	friendly_verb_simple = "wail at"
 	speak_emote = list("bellows")
 	speed = 3
-	maxHealth = 300
-	health = 300
+	maxHealth = 130
+	health = 130
 	harm_intent_damage = 0
-	obj_damage = 100
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	obj_damage = 50
+	melee_damage_lower = 10
+	melee_damage_upper = 20
 	attack_verb_continuous = "pulverizes"
 	attack_verb_simple = "pulverize"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	throw_message = "does nothing to the rocky hide of the"
 	vision_range = 5
 	aggro_vision_range = 9
 	move_force = MOVE_FORCE_VERY_STRONG
@@ -220,7 +219,7 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message(span_danger("[src] grabs hold of [L]!"))
-		L.Stun(100)
+		L.Stun(5 SECONDS)
 		L.adjustBruteLoss(rand(10,15))
 		latched = TRUE
 	if(!latched)

--- a/code/modules/overmap/planets/planet_types/volcanic_planet.dm
+++ b/code/modules/overmap/planets/planet_types/volcanic_planet.dm
@@ -3,7 +3,7 @@
 	area_type = /area/planet/volcanic
 	generator_type = /datum/map_generator/planet_gen/volcanic
 
-	default_traits_input = list(ZTRAIT_MINING = TRUE, ZTRAIT_BASETURF = /turf/open/lava/smooth/lava_land_surface)
+	default_traits_input = list(ZTRAIT_MINING = TRUE, ZTRAIT_BASETURF = /turf/open/misc/asteroid/basalt)
 	overmap_type = /datum/overmap_object/shuttle/planet/volcanic
 	atmosphere_type = /datum/atmosphere/volcanic
 	weather_controller_type = /datum/weather_controller/lavaland


### PR DESCRIPTION
## About The Pull Request

So, basically, Goliaths were balanced. For TG. We are not TG, and they are *severely* overtuned for what people heading planetside would normally be geared with (basic eguns, combat knives, armour vests).

I cut their root time in half, reduced their max damage by 5 (to 20), and reduced their min damage to 10, dropped their health to be in-line with most other fauna, and cut it's obj damage in half, as it was three-tapping shuttle walls, which is very problematic when people are expected to land in the wilderness.

Note: They still 1-tap normal walls, but they can't touch proper r-walls.

Bileworms are hot piles of garbage. Cool concept, awful execution, as their AI never disengages, and they have (relatively) powerful attacks, and a beefy health pool. Instead, let's keep them as a mini-boss of sorts. They only spawn in ruins now.

And also fixes #315 

Closes #314 

## How Does This Help ***Gameplay***?

Makes playing pathfinder on dead/lowpop much more feasible.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Rock smacked
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/8ce3fe6c-0f54-4982-9dd5-c97c7c7e45d7)

It takes *exactly* half an egun to kill a goliath now
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/769b71d5-d5f4-42ba-9212-127d25021e8a)

Tentacles don't root for nearly as long, and it's just enough time for the goliath to get two tiles closer.

Saw no bileworms on lavaland when flying around in ghost either, which is good.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Volcanic planets no longer spawn lava under everything you break.
qol: Goliaths are much less awful to deal with.
balance: Bileworms now only spawn in designated ruins.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
