### PR TITLE
Mop QoL Improvements!

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -59,7 +59,7 @@
 	if(combat_mode) // Stop trying to clean shit you're trying to kill
 		return
 
-	if(istype(attacked, /obj/item/reagent_containers) || istype(attacked, /obj/structure/janitorialcart))
+	if(istype(attacked, /obj/item/reagent_containers/cup/bucket) || istype(attacked, /obj/structure/janitorialcart))
 		return
 
 	if(reagents.total_volume < 0.1)


### PR DESCRIPTION
## About The Pull Request

I was reminded by the folk on daedalus that the mop attack chain is complete hot garbage. Let's fix that.

You no longer smack what you're trying to clean! Wow!

## How Does This Help ***Gameplay***?

Less random smacking of shit.

## How Does This Help ***Roleplay***?

You no longer have to issue a five document essay to the captain apologizing on accidentally smacking them as you were trying to do your damn job with combat mode OFF.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/66b5bf45-3167-4871-bca0-9bf7ddc3d710

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Mops no longer try to smack everything you click on that isn't a turf.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
