### PR TITLE
Fix Pathfinder Encryption Keys!

### DIFF
--- a/code/modules/pathfinders/radio.dm
+++ b/code/modules/pathfinders/radio.dm
@@ -12,14 +12,14 @@
 
 /obj/item/encryptionkey/headset_pth
 	name = "pathfinders radio encryption key"
-	icon_state = "cypherkey_research"
+	icon_state = "cypherkey_pathfinders"
 	channels = list(RADIO_CHANNEL_PATHFINDERS = 1)
 	greyscale_config = /datum/greyscale_config/encryptionkey_pathfinders
 	greyscale_colors = "#847A96#575577"
 
 /obj/item/encryptionkey/headset_pthmed
 	name = "pathfinders medic radio encryption key"
-	icon_state = "cypherkey_research"
+	icon_state = "cypherkey_pathfinders"
 	channels = list(RADIO_CHANNEL_PATHFINDERS = 1, RADIO_CHANNEL_MEDICAL = 1)
 	greyscale_config = /datum/greyscale_config/encryptionkey_pathfinders
 	greyscale_colors = "#847A96#ebebeb"
@@ -32,7 +32,7 @@
 
 /obj/item/encryptionkey/heads/pl
 	name = "\proper the lead pathfinder's encryption key"
-	icon_state = "cypherkey_research"
+	icon_state = "cypherkey_pathfinders"
 	channels = list(RADIO_CHANNEL_PATHFINDERS = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_COMMAND = 1)
 	greyscale_config = /datum/greyscale_config/encryptionkey_pathfinders
-	greyscale_colors = "#847A96#575577"
+	greyscale_colors = "#7c7a96#231e61"


### PR DESCRIPTION
## About The Pull Request

This took an embarrassingly long time to figure out.

Also made the pathfinder lead key look different from the pathfinder one. Woops.

Closes #247 

## How Does This Help ***Gameplay***?

No more error signs! Yay!

## Proof of Testing

Pictured: Pathmed, Pathfinder, and Lead Pathfinder keys.
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/c3b0ab41-0b5f-4864-bc12-e0da4163b9fd)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Pathfinder encryption keys now display properly.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
