### PR TITLE
Fix Parallax Runtime On Player Join

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -175,7 +175,7 @@
 
 	var/destined_parallax_movedir = areaobj.parallax_movedir
 	var/datum/space_level/my_level
-	if(SSmapping && screenmob.z)
+	if(SSmapping.initialized && screenmob.z)
 		my_level = SSmapping.z_list[screenmob.z]
 	if(my_level && my_level.related_overmap_object)
 		destined_parallax_movedir = my_level.parallax_direction_override

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -175,7 +175,7 @@
 
 	var/destined_parallax_movedir = areaobj.parallax_movedir
 	var/datum/space_level/my_level
-	if(SSmapping.initialized && screenmob.z)
+	if(SSmapping?.initialized && screenmob.z)
 		my_level = SSmapping.z_list[screenmob.z]
 	if(my_level && my_level.related_overmap_object)
 		destined_parallax_movedir = my_level.parallax_direction_override

--- a/code/controllers/subsystem/lobby_eye_ss.dm
+++ b/code/controllers/subsystem/lobby_eye_ss.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(lobby_eye)
 	///the areas that are considered invalid
 	var/static/list/invalid_areas = list(/area/space, /area/icemoon)
 	///how fast the camera will "move"
-	var/moving_speed = 2
+	var/moving_speed = 4
 	///the screen that will fade in and out
 	var/atom/movable/screen/movable/black_fade/fading_screen
 	///the pathway that the camera will take


### PR DESCRIPTION
## About The Pull Request

Fixes a runtime that can happen if a player joins before SSMapping has initialized.

**Sadly, this does not fix the lobby camera parallax bug, as that is something entirely separate.**

Closes #113 

## Proof of Testing

It compiled, I joined before the station initialized, and it didn't cry about it. Nothing to show.

## Changelog

Non player facing.
