### PR TITLE
Fix Interaction Particle Catching Clicks

### DIFF
--- a/code/modules/interaction_particle/interaction_particle.dm
+++ b/code/modules/interaction_particle/interaction_particle.dm
@@ -4,6 +4,7 @@
 	icon_state = "interact"
 	alpha = 180
 	layer = ABOVE_ALL_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /mob/proc/animate_interact(atom/target, state)
 	set waitfor = FALSE


### PR DESCRIPTION
## About The Pull Request

I noticed when spam clicking buttons that the interaction particle is clickable. Uh, woops.

## How Does This Help ***Gameplay***?

Spamclicking buttons?

## Proof of Testing

Nothing really to show.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Interaction particles no longer block clicks.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
