### PR TITLE
Synth Digi Legs Option Now Hides If Chassis Doesn't Support It

### DIFF
--- a/code/modules/client/preferences/species_features/lizard.dm
+++ b/code/modules/client/preferences/species_features/lizard.dm
@@ -63,6 +63,14 @@ MUTANT_CHOICED_NEW(lizard_frills, GLOB.frills_list)
 	category = PREFERENCE_CATEGORY_APPEARANCE_LIST
 	relevant_mutant_bodypart = "legs"
 
+/datum/preference/choiced/lizard_legs/is_accessible(datum/preferences/preferences)
+	if(ispath(preferences?.read_preference(/datum/preference/choiced/species), /datum/species/synthetic))
+		var/datum/sprite_accessory/synth_chassis/chassis = GLOB.synth_chassi[preferences.read_preference(/datum/preference/choiced/mutant/synth_chassis)]
+		if(chassis)
+			return initial(chassis.is_digi_compatible)
+
+	return ..()
+
 /datum/preference/choiced/lizard_legs/init_possible_values()
 	return assoc_to_keys(GLOB.legs_list)
 


### PR DESCRIPTION
## About The Pull Request

Tin.

Closes #323 

## How Does This Help ***Gameplay***?

Makes it much more obvious that it **isn't** a bug that digi legs don't work on some synth frames.

I'm likely to make this a subspecies thing in the future, when I get the systems in place for it.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Human chassis, plantigrade only, so no option.
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/55f0a58c-1128-45e2-b29a-39d24b638006)

Lizard chassis, which has both options, so option is shown.
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/38a1ae10-70c5-428c-b5d4-cbcc2e9fdeb1)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Synth digi legs option now hides if the selected chassis isn't compatible.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
