### PR TITLE
Fixes Space Ruins Not All Generating

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -407,8 +407,7 @@ Used by the AI doomsday and the self-destruct nuke.
 		qdel(query_round_map_name)
 
 #ifndef LOWMEMORYMODE
-	// TODO: remove this when the DB is prepared for the z-levels getting reordered
-	while (world.maxz < 5 && space_levels_so_far < config.space_ruin_levels)
+	while (space_levels_so_far < config.space_ruin_levels)
 		++space_levels_so_far
 		add_new_zlevel("Ruins Area [space_levels_so_far]", ZTRAITS_SPACE, overmap_obj = new /datum/overmap_object/ruins(SSovermap.main_system, rand(1,SSovermap.main_system.maxx), rand(1,SSovermap.main_system.maxy)))
 	//Load planets


### PR DESCRIPTION
## About The Pull Request

Turns out that the code for space-zs that I copied from Horizon had a check that is now completely invalid and unnecessary.

It yeets that check.

Fixes #310 

## How Does This Help ***Gameplay***?

Oh look, Pathfinders actually have space content!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

The full 7 ruin Zs generated, and I tested to make sure multi-z setups (literally just the station) aren't fucked. It's all fine. Planets are fine too. Yup.

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/4ea416cf-52eb-4d9a-b7ea-3218242e54fa)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/e081cfec-7a82-4836-b869-c8532896e5f5)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Ruin clusters should now properly generate on Bearcat.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
