### PR TITLE
Makes Limbs Unashable

### DIFF
--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -67,7 +67,7 @@
 			if(WOUND_PIERCE)
 				occur_text = "is outright blasted apart, severing it completely!"
 			if(WOUND_BURN)
-				occur_text = "is outright incinerated, falling to dust!"
+				occur_text = "is outright melted, severing it completely!"
 	else
 		var/bone_text = get_internal_description()
 		var/tissue_text = get_external_description()
@@ -80,6 +80,6 @@
 			if(WOUND_PIERCE)
 				occur_text = "is pierced through the last [tissue_text] holding it together, severing it completely!"
 			if(WOUND_BURN)
-				occur_text = "is completely incinerated, falling to dust!"
+				occur_text = "is melted though the last [tissue_text] holding it together, severing it completely!"
 
 	return occur_text


### PR DESCRIPTION
## About The Pull Request

Turns out limbs were directly ashable! This removes that behavior, cause having a limb permanently gone after an accidental weldering as a synth seems pretty dumb.

Instead, it dismembers, just like it would from literally any other damage type.

Oh, and also makes dismembering make noise by default, cause that being silent by default doesn't seem intentional.

## How Does This Help ***Gameplay***?

Playing synths is less CBT, engis and other jobs that deal with fires won't get their limbs ashed from fires.

Closes #311 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/686edff6-ac60-49fa-b553-78d8ad545139
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Limbs no longer ash from burn damage, they dismember instead.
fix: Dismembering makes much more noise than it used to.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
