### PR TITLE
[Port] Nicer Chat readability tweak from DD

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -109,7 +109,7 @@
 			if(!ghost.client || isnewplayer(ghost))
 				continue
 			if(ghost.client.prefs.chat_toggles & CHAT_GHOSTSIGHT && !(ghost in viewers(user_turf, null)))
-				ghost.show_message("<span class='emote'>[FOLLOW_LINK(ghost, user)] [dchatmsg]</span>")
+				ghost.show_message("[FOLLOW_LINK(ghost, user)]<span class='emote'> [dchatmsg]</span>")
 	if(emote_type & (EMOTE_AUDIBLE | EMOTE_VISIBLE)) //emote is audible and visible
 		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
 	else if(emote_type & EMOTE_VISIBLE)	//emote is only visible

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -84,9 +84,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE, visible_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.
 	//Basic span
-	var/spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
+	var/wrapper_span = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
 	//Start name span.
-	var/spanpart2 = "<span class='name'>"
+	var/name_span = "<span class='name'>"
 	//Radio freq/name display
 	var/freqpart = radio_freq ? "\[[get_radio_name(radio_freq)]\] " : ""
 	//Speaker name
@@ -100,11 +100,16 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	//End name span.
 	var/endspanpart = "</span>"
 
+	//href for AI tracking
+	var/ai_track_href = compose_track_href(speaker, namepart)
+	//shows the speaker's job to AIs
+	var/ai_job_display = compose_job(speaker, message_language, raw_message, radio_freq)
+
 	//Message
 	var/messagepart
 	var/languageicon = ""
 	if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
-		messagepart = message_mods[MODE_CUSTOM_SAY_EMOTE]
+		messagepart = "<span class='emote'>[message_mods[MODE_CUSTOM_SAY_EMOTE]]</span>"
 	else
 		messagepart = lang_treat(speaker, message_language, raw_message, spans, message_mods)
 
@@ -112,9 +117,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		if(istype(D) && D.display_icon(src))
 			languageicon = "[D.get_icon()] "
 
-	messagepart = " <span class='message'>[say_emphasis(messagepart)]</span></span>"
+	messagepart = " <span class='message'>[speaker.say_emphasis(messagepart)]</span></span>" //These close the wrapper_span and the "message" class span
 
-	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, namepart)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
+	return "[wrapper_span][freqpart][name_span][languageicon][ai_track_href][namepart][ai_job_display][endspanpart][messagepart]"
 
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
@@ -151,7 +156,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		spans |= SPAN_YELL
 
 	var/spanned = attach_spans(input, spans)
-	return "[say_mod], \"[spanned]\""
+	return "<span class='sayverb'>[say_mod],</span> \"[spanned]\""
 
 /// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.
 #define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
@@ -174,10 +179,12 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/atom/movable/source = speaker.GetSource() || speaker //is the speaker virtual
 	if(has_language(language))
 		return no_quote ? raw_message : source.say_quote(raw_message, spans, message_mods)
+
 	else if(language)
 		var/datum/language/D = GLOB.language_datum_instances[language]
 		raw_message = D.scramble(raw_message)
 		return no_quote ? raw_message : source.say_quote(raw_message, spans, message_mods)
+
 	else
 		return "makes a strange sound."
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -245,7 +245,7 @@
  * * vision_distance (optional) define how many tiles away the message can be seen.
  * * ignored_mob (optional) doesn't show any message to a given mob if TRUE.
  */
-/atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, visible_message_flags = NONE)
+/atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, visible_message_flags = NONE, separation = " ")
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
@@ -260,7 +260,7 @@
 
 	var/raw_msg = message
 	if(visible_message_flags & EMOTE_MESSAGE)
-		message = "<span class='emote'><b>[src]</b> [message]</span>"
+		message = "<b>[src]</b><span class='emote'>[separation][message]</span>"
 
 	for(var/mob/M in hearers)
 		if(!M.client)

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -898,3 +898,16 @@ em {
   font-style: italic;
   border-bottom: 1px dashed #fff;
 }
+
+.talk {
+  //color: #A5D6C1;
+}
+
+.sayverb {
+  color: #bbbbad;
+  font-style: italic;
+}
+
+.emote {
+  color: #bbbbad;
+}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -930,3 +930,12 @@ h2.alert {
   font-style: italic;
   border-bottom: 1px dashed #000;
 }
+
+.sayverb {
+  color: #2e2e2e;
+  font-style: italic;
+}
+
+.emote {
+  color: #2e2e2e;
+}


### PR DESCRIPTION
## About The Pull Request

This PR is a port of the following PR:
- https://github.com/DaedalusDock/daedalusdock/pull/616

This PR changes some spans for chats to make readability easier, See Testing proof to see what I'm talking about.

## How Does This Help ***Gameplay***?
Having an easier time reading the chat is always nice 

## How Does This Help ***Roleplay***?
Easier Immersion? idk tbh but its nice to have like this.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/52a68cf5-03fc-4ce9-bc91-715e3bf6885a)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/637b27b2-7d64-4bba-a9fc-9acd49a7f99c)

</details>

## Changelog
:cl:
qol: Chat is easier to read now yippee (Debolded some radio stuff and made it easier to read)
/:cl: