### PR TITLE
[Bearcat] Rework Engi Lathe Room and Bar, Misc Changes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/iron,
 /area/ruin/planetengi)
 "aA" = (
-/obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 9
 	},

--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -5679,7 +5679,6 @@
 /obj/machinery/door/airlock/command{
 	name = "E.V.A."
 	},
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/command/storage/eva)
 "GI" = (

--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -70,16 +70,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "av" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "aw" = (
 /obj/structure/curtain,
 /obj/item/soap,
@@ -130,7 +129,7 @@
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "aU" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -258,6 +257,20 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/command/meeting_room)
+"bE" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks/beer{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "bH" = (
 /obj/machinery/rnd/server,
 /obj/structure/window/reinforced/spawner/east,
@@ -365,8 +378,8 @@
 "cj" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "ck" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/closet/secure_closet/hop{
@@ -403,7 +416,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "cr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -434,12 +447,20 @@
 	pixel_x = 6;
 	pixel_y = 35
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "cv" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"cy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled{
+	pixel_y = 9
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "cA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -460,10 +481,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "cI" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "cK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -608,6 +631,10 @@
 "dE" = (
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
+"dG" = (
+/obj/machinery/mineral/processing_unit_console,
+/turf/closed/wall,
+/area/station/cargo/sorting)
 "dJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -658,6 +685,7 @@
 "dU" = (
 /obj/machinery/recharge_station,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "dX" = (
@@ -731,13 +759,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "ep" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Bar"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "er" = (
 /obj/item/storage/toolbox/emergency,
@@ -848,6 +876,8 @@
 /area/station/medical/medbay)
 "eO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/red,
 /area/station/science/robotics/lab)
 "eQ" = (
@@ -857,16 +887,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"eR" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/starboard)
 "eS" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/table/reinforced,
@@ -953,6 +973,16 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/starboard)
+"fr" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/service/bar)
 "fs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -988,6 +1018,7 @@
 /area/station/hallway/primary/central/fore)
 "fB" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/fore)
 "fC" = (
@@ -1005,6 +1036,11 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"fJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "fK" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/machinery/light/directional/west,
@@ -1032,7 +1068,7 @@
 "fQ" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/kitchen/herringbone,
 /area/station/service/hydroponics)
 "fR" = (
 /obj/structure/cable,
@@ -1128,6 +1164,7 @@
 /area/station/engineering/main)
 "gy" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "gz" = (
@@ -1159,6 +1196,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "gJ" = (
+/obj/structure/sink/directional/west,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "gK" = (
@@ -1222,6 +1260,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"hl" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/plating,
+/area/station/hallway/primary/upper/starboard)
 "hn" = (
 /obj/item/stack/ore/glass{
 	amount = 2
@@ -1246,19 +1288,10 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/openspace,
 /area/station/service/bar)
-"hq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
 "hr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/circuit/red,
 /area/station/science/robotics/lab)
 "ht" = (
@@ -1366,12 +1399,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ij" = (
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "im" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/firealarm/directional/north,
@@ -1404,6 +1435,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "is" = (
@@ -1430,16 +1462,17 @@
 /area/station/engineering/supermatter/room)
 "iy" = (
 /obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 7;
+	pixel_x = -5
 	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "iz" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
@@ -1447,10 +1480,14 @@
 /turf/open/floor/wood,
 /area/station/service/bar)
 "iD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "iE" = (
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/vomit/old,
@@ -1519,9 +1556,6 @@
 "iU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
-/obj/machinery/mineral/processing_unit_console{
-	pixel_x = 32
-	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "iW" = (
@@ -1563,7 +1597,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "ji" = (
 /obj/machinery/firealarm/directional/north,
@@ -1631,8 +1665,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "jD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1644,6 +1678,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
+"jE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/bar)
 "jH" = (
 /obj/item/poster/random_official,
 /turf/open/floor/iron/smooth,
@@ -1700,14 +1741,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"jX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
 "jY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1717,17 +1750,8 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/port)
-"jZ" = (
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
-"kc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/starboard)
 "kd" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "kg" = (
@@ -1789,12 +1813,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
 /area/station/service/bar)
-"kC" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/service/bar)
 "kD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1806,6 +1824,9 @@
 /obj/item/stack/tile/iron/dark_side,
 /turf/open/floor/plating,
 /area/station/commons/storage/cryo)
+"kG" = (
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "kM" = (
 /obj/machinery/telecomms/relay/preset/station,
 /obj/effect/decal/cleanable/dirt,
@@ -1816,6 +1837,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "kS" = (
@@ -1886,8 +1908,8 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "li" = (
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "lj" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2170,7 +2192,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "mA" = (
 /obj/docking_port/stationary/huge{
 	name = "FTV Bearcat Cargo Dock"
@@ -2184,8 +2206,10 @@
 /area/station/engineering/main)
 "mC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "mD" = (
 /obj/structure/lattice,
@@ -2235,10 +2259,6 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
-"mU" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
 "mV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2297,7 +2317,7 @@
 "nj" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "nk" = (
 /obj/structure/lattice/catwalk,
@@ -2369,6 +2389,11 @@
 	dir = 8
 	},
 /area/station/commons/storage/cryo)
+"nz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/circuit/red,
+/area/station/science/robotics/lab)
 "nB" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -2387,7 +2412,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nH" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plating,
 /area/station/hallway/primary/upper/starboard)
 "nI" = (
@@ -2588,8 +2613,8 @@
 "oF" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "oG" = (
 /obj/machinery/transporter,
 /turf/open/floor/iron,
@@ -2691,7 +2716,7 @@
 "pl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/closed/wall/r_wall,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "pm" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 8
@@ -2719,7 +2744,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/four,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "pv" = (
 /obj/machinery/power/terminal{
@@ -2760,7 +2785,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/kitchen/herringbone,
 /area/station/service/hydroponics)
 "pJ" = (
 /obj/structure/cable,
@@ -2964,8 +2989,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/meeting_room)
 "qJ" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "qM" = (
 /obj/machinery/light_switch/directional/north,
@@ -3113,8 +3140,8 @@
 	layer = 5;
 	pixel_x = -4
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "rH" = (
 /obj/structure/sign/directions/command{
 	pixel_y = -8
@@ -3126,16 +3153,8 @@
 /turf/closed/wall,
 /area/station/commons/storage/cryo)
 "rJ" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_x = -32
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "rK" = (
@@ -3177,6 +3196,11 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"rU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "rV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3189,8 +3213,8 @@
 "rX" = (
 /obj/machinery/griddle,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "rY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -3385,6 +3409,7 @@
 	name = "Engineering"
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "tr" = (
@@ -3494,11 +3519,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/starboard)
 "tU" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
@@ -3529,8 +3554,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "ug" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -3598,7 +3623,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/machinery/door/airlock/hydroponics/glass,
-/turf/open/floor/plating,
+/turf/open/floor/iron/kitchen/herringbone,
 /area/station/service/hydroponics)
 "ut" = (
 /obj/structure/cable,
@@ -3718,8 +3743,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "uV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -3763,6 +3788,11 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"ve" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor,
+/turf/closed/wall,
+/area/station/service/bar)
 "vg" = (
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/smooth_large,
@@ -3793,7 +3823,7 @@
 "vk" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/kitchen/herringbone,
 /area/station/service/hydroponics)
 "vl" = (
 /obj/structure/table/wood,
@@ -3873,8 +3903,8 @@
 	pixel_x = 5
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "vE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3890,10 +3920,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
 /turf/open/floor/plating,
 /area/station/hallway/primary/upper/port)
+"vH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "vO" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/robot_debris,
@@ -4199,13 +4237,6 @@
 	dir = 1
 	},
 /area/station/pathfinders)
-"xV" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
 "xX" = (
 /obj/structure/sign/poster/contraband/free_drone{
 	pixel_y = 32
@@ -4337,15 +4368,13 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms/barracks)
 "yG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "yH" = (
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "yI" = (
 /turf/open/floor/iron,
@@ -4440,13 +4469,6 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space)
-"zk" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/station/service/bar)
 "zm" = (
 /obj/machinery/light/directional/west,
 /obj/structure/reagent_dispensers/watertank,
@@ -4512,7 +4534,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "zM" = (
-/obj/structure/table/wood,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/service/bar)
 "zN" = (
@@ -4794,14 +4818,26 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
+"BH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 2;
+	pixel_x = -8
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "BI" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 5
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "BJ" = (
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -4832,8 +4868,8 @@
 /area/station/cargo/warehouse)
 "BQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "BR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/telecomms/relay/preset/station,
@@ -5044,10 +5080,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "CW" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/starboard)
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "Db" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/circuit,
@@ -5090,12 +5125,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
-"Dk" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/area/station/service/kitchen)
 "Do" = (
 /obj/structure/cable,
 /obj/structure/closet/radiation,
@@ -5214,9 +5244,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/starboard)
 "Ed" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck/wizoff{
+	pixel_y = 6
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
@@ -5338,6 +5372,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"EM" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/service/bar)
 "EN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5365,7 +5405,13 @@
 "EU" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar)
+"EV" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood,
 /area/station/service/bar)
 "EY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5410,8 +5456,8 @@
 /area/station/hallway/secondary/exit)
 "Fj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "Fk" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
@@ -5517,13 +5563,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/port)
 "Gc" = (
-/obj/effect/spawner/random/structure/crate,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/lightreplacer,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "Gd" = (
@@ -5584,7 +5634,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "Gq" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
@@ -5646,13 +5696,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"GL" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/service/bar)
 "GM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5663,14 +5706,6 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/openspace,
-/area/station/service/bar)
-"GN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bar"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
-/turf/open/floor/iron,
 /area/station/service/bar)
 "GP" = (
 /turf/closed/wall/rust,
@@ -5785,7 +5820,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "Hq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -5917,7 +5952,7 @@
 /area/station/engineering/main)
 "Ib" = (
 /turf/closed/wall/r_wall,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "Id" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6020,9 +6055,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "IE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/wood,
+/area/station/service/bar)
 "IF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -6035,6 +6074,13 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/pathfinders)
+"IG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "IH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6113,13 +6159,6 @@
 /obj/structure/ladder,
 /turf/open/openspace,
 /area/station/science/research/abandoned)
-"IY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
 "Ja" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6138,8 +6177,8 @@
 /area/station/hallway/primary/central/fore)
 "Jc" = (
 /obj/structure/table,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "Jd" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -6196,9 +6235,10 @@
 /area/station/cargo/warehouse)
 "Jz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "JC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6207,6 +6247,12 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
@@ -6233,7 +6279,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "JQ" = (
 /obj/structure/marker_beacon/burgundy,
 /obj/structure/sign/warning/fire{
@@ -6274,7 +6320,7 @@
 /area/station/hallway/primary/upper/starboard)
 "Kc" = (
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "Kd" = (
 /obj/structure/bed,
@@ -6431,7 +6477,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/area/station/service/kitchen)
 "KU" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/segment,
@@ -6582,13 +6628,11 @@
 /area/station/service/kitchen/coldroom)
 "LC" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/hallway/primary/upper/port)
+/area/station/hallway/primary/central/fore)
 "LD" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
@@ -6650,8 +6694,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/disposalpipe/junction,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "LY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/south{
@@ -6691,6 +6736,7 @@
 /area/station/engineering/storage)
 "Mf" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/starboard)
 "Mg" = (
@@ -6705,13 +6751,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/port)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "Mm" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "Mn" = (
 /obj/effect/decal/cleanable/chem_pile,
 /obj/machinery/holopad,
@@ -6750,10 +6796,12 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "MB" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/circuit/red,
 /area/station/science/robotics/lab)
 "MC" = (
@@ -6822,23 +6870,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"MT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
 "MW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
 "Na" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
+/obj/structure/chair/stool/bar/directional/west,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "Nc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/north,
@@ -6871,6 +6911,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"Nq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Shuttle Docks"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "Ns" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -6885,6 +6937,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"Nv" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_y = 13;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "Nw" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -7068,14 +7137,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/openspace,
 /area/station/service/bar)
-"Ok" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
 "Om" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/lattice/catwalk,
@@ -7083,11 +7144,11 @@
 /obj/structure/supplies_box/engineering,
 /turf/open/openspace,
 /area/station/service/bar)
-"Op" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood,
-/area/station/service/bar)
+"Oo" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/fore)
 "Oq" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/iron/smooth,
@@ -7152,7 +7213,7 @@
 "OG" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/supplies_box/common,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "OJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7250,10 +7311,6 @@
 /obj/structure/ladder,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/starboard)
-"Pe" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
 "Pf" = (
 /obj/docking_port/stationary/mining_home/kilo{
 	dir = 4;
@@ -7410,8 +7467,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "PX" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -7421,6 +7478,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/storage/book/bible/booze,
 /obj/item/clothing/glasses/regular/thin,
+/obj/machinery/light_switch/directional/north,
+/obj/item/clothing/head/kitty{
+	name = "crusty kitty ears";
+	pixel_y = 11
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "Qb" = (
@@ -7483,6 +7545,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "Qw" = (
@@ -7495,10 +7559,16 @@
 "Qx" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/vending/dinnerware/deluxe,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "Qy" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/service/bar)
 "Qz" = (
@@ -7522,7 +7592,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/area/station/service/kitchen)
 "QF" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -7781,6 +7851,13 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"RT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "RU" = (
 /obj/effect/mapping_helpers/paint_wall/bridge,
 /turf/closed/wall/r_wall,
@@ -7798,10 +7875,9 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal)
 "RY" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/hallway/primary/upper/port)
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "RZ" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/port/aft)
@@ -7828,8 +7904,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "Sh" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -7862,9 +7938,6 @@
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
 "Sr" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/bar)
@@ -7905,15 +7978,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/table,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
-"SA" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/service/bar)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "SB" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -7937,10 +8003,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"SG" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/starboard)
 "SH" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -7974,6 +8036,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"SQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar)
 "ST" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -8008,6 +8077,14 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
+"Td" = (
+/obj/machinery/door/airlock{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/service)
 "Tg" = (
 /obj/machinery/processor,
 /turf/open/floor/iron/freezer,
@@ -8023,6 +8100,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "Tm" = (
@@ -8151,6 +8229,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/service/bar)
+"TS" = (
+/obj/structure/table/wood,
+/obj/item/storage/dice,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "TT" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -8186,7 +8269,7 @@
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
 "Ud" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "Ue" = (
 /obj/machinery/door/airlock{
@@ -8293,12 +8376,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/command/meeting_room)
 "UC" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/obj/effect/spawner/structure/window/wood,
 /obj/effect/turf_decal/siding/wood{
-	dir = 10
+	dir = 8
 	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "UF" = (
@@ -8382,11 +8463,9 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "Vd" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "Ve" = (
@@ -8477,6 +8556,9 @@
 /area/station/security)
 "VK" = (
 /obj/machinery/rnd/production/techfab/department/service,
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "VL" = (
@@ -8515,6 +8597,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/meeting_room)
+"Wa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "Wf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8540,8 +8630,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "Wj" = (
 /turf/open/floor/plating,
 /area/station/pathfinders/pathfinders_armory)
@@ -8563,8 +8653,8 @@
 "Wt" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "Wu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/meter/layer2,
@@ -8676,8 +8766,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/primary/upper/port)
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "WW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
@@ -8811,6 +8901,7 @@
 "XP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "XQ" = (
@@ -8865,7 +8956,7 @@
 /area/station/engineering/supermatter/room)
 "Yh" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/service/bar)
 "Yi" = (
 /obj/machinery/button/door/directional/east{
@@ -8939,6 +9030,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"Yz" = (
+/obj/machinery/light/directional/west,
+/obj/effect/spawner/structure/window/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "YD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk/multiz{
@@ -8946,13 +9045,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
+"YF" = (
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "YG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen/diner)
+/turf/open/floor/iron/kitchen/herringbone,
+/area/station/service/kitchen)
 "YM" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
@@ -9157,12 +9260,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ZR" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "ZS" = (
@@ -105979,7 +106081,7 @@ XF
 pc
 FD
 hr
-eO
+nz
 dB
 pc
 NK
@@ -107006,7 +107108,7 @@ jY
 fv
 UH
 mu
-eD
+rU
 sY
 BR
 DJ
@@ -107264,7 +107366,7 @@ fv
 gx
 FA
 Ia
-sY
+IG
 eX
 DJ
 NK
@@ -108014,7 +108116,7 @@ NK
 QZ
 Fg
 lD
-Se
+dG
 lD
 Se
 JU
@@ -171230,8 +171332,8 @@ sW
 lj
 sW
 BX
-eB
-Ns
+sW
+sW
 Ns
 Ns
 Ns
@@ -171487,19 +171589,19 @@ EJ
 Io
 gy
 xd
-RY
+EJ
+Oo
 Oh
-sm
 sm
 Rg
 Nn
 Ta
-KS
+sm
 ue
 Mm
-sm
+kG
 BQ
-sm
+kG
 BQ
 Sg
 PV
@@ -171745,17 +171847,17 @@ zG
 ZP
 yR
 LC
-FY
+Nq
 FY
 WX
 Lc
-Ok
+NW
 Nz
 vF
 uU
 WU
-NW
-Nz
+av
+Wa
 av
 Mh
 Wi
@@ -172002,18 +172104,18 @@ Nt
 EJ
 EJ
 RY
-Dk
-sm
-mU
 Kr
 Kr
 GZ
 Kr
+jE
+EM
+EM
 Jz
 qJ
 qJ
 mC
-Kr
+SQ
 Kr
 Kr
 Kr
@@ -172260,10 +172362,10 @@ Gw
 Gw
 Gw
 Gw
-sm
-cI
-Kr
 xY
+cI
+Yz
+RT
 Vd
 UC
 Ed
@@ -172517,15 +172619,15 @@ Gw
 uS
 Gc
 Gw
-sm
+bE
 ij
-Kr
+Nv
 rJ
-BW
-kd
 et
-zM
 kd
+TS
+zM
+Ej
 Yh
 EU
 NE
@@ -172775,14 +172877,14 @@ iy
 rP
 ep
 IE
-MT
-GN
-yG
 vA
 Pz
+yG
 Sr
-GL
-zk
+Sr
+Sr
+BW
+Ej
 Kc
 yH
 NE
@@ -173031,15 +173133,15 @@ Gw
 PZ
 WO
 Gw
-Mf
-IY
-Kr
 Xb
 DD
 oD
-Sr
-Op
-Ej
+YF
+et
+kd
+cy
+zM
+EV
 Ud
 yH
 NE
@@ -173287,13 +173389,13 @@ Nt
 Gw
 VK
 gJ
-Gw
-jZ
-Na
-GZ
+Td
 qa
-kC
-SA
+Na
+fJ
+et
+et
+et
 PS
 fF
 Yt
@@ -173546,11 +173648,11 @@ Gw
 Gw
 Gw
 iD
-Na
-GZ
-ZR
 yY
 mE
+ZR
+BH
+vH
 OK
 lJ
 gK
@@ -173801,16 +173903,16 @@ Nt
 EJ
 qC
 CW
-Pe
-Mf
-xV
 Kr
+ve
+Os
 Kr
-GZ
-Kr
+fr
+fr
+fr
 JC
-qJ
-qJ
+fr
+fr
 Qy
 Kr
 Kr
@@ -174057,14 +174159,14 @@ Rs
 Jb
 yR
 fy
-eR
-tR
+ZP
+Nq
 tR
 IA
 eL
-jX
 VG
-hq
+VG
+tR
 Ea
 Kb
 Rm
@@ -174314,14 +174416,14 @@ aj
 uW
 fB
 WL
-CW
-SG
+EJ
+Oo
 nH
 Mf
 kD
 Gn
+hl
 NZ
-kc
 UV
 oc
 Vy
@@ -174571,8 +174673,8 @@ sW
 yV
 sW
 BX
-qh
-VL
+sW
+BX
 VL
 VL
 VL

--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -51,10 +51,21 @@
 /turf/open/openspace,
 /area/station/maintenance/solars/port/aft)
 "aq" = (
-/obj/machinery/telecomms/relay/preset/station,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit,
-/area/station/construction/storage_wing)
+/obj/machinery/newscaster/directional/north,
+/obj/structure/table/optable,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
+"ar" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light/broken/directional/west,
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "at" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -581,8 +592,8 @@
 /obj/item/stack/sheet/iron/ten,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "dC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
@@ -591,6 +602,7 @@
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/bag/chemistry,
 /obj/machinery/airalarm/directional/north,
+/obj/item/crowbar,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dE" = (
@@ -624,9 +636,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -648,8 +657,9 @@
 /area/station/tcommsat/server)
 "dU" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "dX" = (
 /obj/machinery/door/poddoor{
 	id = "supermatter_blast"
@@ -838,14 +848,15 @@
 /area/station/medical/medbay)
 "eO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/circuit/red,
+/area/station/science/robotics/lab)
 "eQ" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "eR" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock,
@@ -875,7 +886,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "fc" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -1018,10 +1029,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
-"fP" = (
-/obj/machinery/mineral/processing_unit_console,
-/turf/closed/wall,
-/area/station/cargo/sorting)
 "fQ" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
@@ -1090,8 +1097,11 @@
 /area/station/command/heads_quarters/captain)
 "gu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/chair/stool{
+	pixel_x = -5
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms/barracks)
 "gv" = (
@@ -1228,6 +1238,7 @@
 	dir = 2
 	},
 /obj/machinery/disposal/bin,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "hp" = (
@@ -1248,8 +1259,8 @@
 "hr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/circuit/red,
+/area/station/science/robotics/lab)
 "ht" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
@@ -1361,9 +1372,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/port)
-"il" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/aft/lesser)
 "im" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/firealarm/directional/north,
@@ -1511,6 +1519,9 @@
 "iU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
+/obj/machinery/mineral/processing_unit_console{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "iW" = (
@@ -1623,7 +1634,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen/diner)
 "jD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/caution{
@@ -1793,9 +1803,7 @@
 /area/station/hallway/primary/upper/starboard)
 "kF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/stack/tile/iron/dark_side{
-	turf_dir = 1
-	},
+/obj/item/stack/tile/iron/dark_side,
 /turf/open/floor/plating,
 /area/station/commons/storage/cryo)
 "kM" = (
@@ -1807,8 +1815,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "kS" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/red{
@@ -1931,6 +1940,16 @@
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
+"lx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Bunks"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/commons/dorms/barracks)
 "lz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/thinplating{
@@ -2128,6 +2147,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
+"mu" = (
+/obj/machinery/rnd/production/techfab/department/engineering,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "mv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2203,9 +2231,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "mS" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "mU" = (
 /obj/machinery/light/directional/south,
@@ -2386,18 +2414,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
-"nQ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/rnd/production/techfab/department/engineering,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
 "nR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2407,8 +2423,9 @@
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "nV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -2444,12 +2461,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/command/meeting_room)
-"oh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
 "om" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -2501,6 +2512,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/glass{
+	id_tag = "bearcat_maintdoor"
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
@@ -2571,10 +2585,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/bar)
-"oE" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/port)
 "oF" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -2663,7 +2673,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/construction/storage_wing)
+/area/station/science/robotics/lab)
 "pd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
@@ -2819,6 +2829,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/sign/directions/dorms/directional/east,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/starboard)
 "qf" = (
@@ -2923,8 +2934,11 @@
 /area/station/hallway/primary/central/fore)
 "qE" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "qF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2985,10 +2999,10 @@
 /area/station/maintenance/solars/port/aft)
 "qX" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/table,
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/suture,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rd" = (
@@ -3313,20 +3327,15 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/station/hallway/primary/aft)
 "sY" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/construction/storage_wing)
+/area/station/engineering/main)
 "sZ" = (
 /turf/closed/wall,
 /area/station/medical/pharmacy)
 "ta" = (
-/obj/machinery/light/broken/directional/west,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -3371,8 +3380,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "tr" = (
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 1
@@ -3581,12 +3595,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "uq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	dir = 2;
-	name = "Hydroponics Window"
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/machinery/door/airlock/hydroponics/glass,
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "ut" = (
@@ -3869,7 +3880,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/glass{
+	name = "Dorms"
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "vF" = (
@@ -4115,6 +4128,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"xB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/plating,
+/area/station/medical/pharmacy)
 "xH" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Quartermaster's Office"
@@ -4155,8 +4173,21 @@
 /turf/open/space/basic,
 /area/station/hallway/secondary/exit)
 "xQ" = (
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/retractor,
+/obj/item/cautery,
+/obj/item/circular_saw,
+/obj/item/hemostat,
+/obj/item/scalpel{
+	pixel_y = 16
+	},
+/obj/item/surgical_drapes,
+/turf/open/floor/circuit/red,
+/area/station/science/robotics/lab)
 "xS" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
@@ -4333,11 +4364,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "yU" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4439,16 +4466,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
-"zz" = (
-/obj/machinery/door/airlock{
-	name = "Bunks"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/commons/dorms/barracks)
 "zA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4608,13 +4625,6 @@
 "Au" = (
 /turf/closed/wall/r_wall,
 /area/station/service/kitchen/coldroom)
-"Av" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
 "Aw" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -4624,7 +4634,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
 "AB" = (
-/obj/machinery/vending/engivend,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/crate,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "AC" = (
@@ -4650,10 +4661,12 @@
 /area/station/commons/dorms/barracks)
 "AG" = (
 /obj/item/radio/intercom/directional/south,
-/obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "AH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4766,12 +4779,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
 "Bx" = (
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/machinery/light/small/directional/west,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "BC" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron,
@@ -4779,6 +4791,7 @@
 "BD" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "BI" = (
@@ -4822,8 +4835,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper/port)
 "BR" = (
-/turf/closed/wall,
-/area/station/construction/storage_wing)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/circuit,
+/area/station/engineering/main)
 "BT" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -4931,20 +4946,16 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"Cs" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+"Cr" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/vending/clothing/deluxe,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "Cu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"Cv" = (
-/turf/closed/wall,
-/area/station/maintenance/aft/lesser)
 "Cw" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
@@ -5141,6 +5152,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/security)
+"DJ" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "DK" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit,
@@ -5298,11 +5312,13 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/exit)
 "ED" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/computer/operating,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "EF" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -5352,13 +5368,11 @@
 /turf/open/floor/iron,
 /area/station/service/bar)
 "EY" = (
-/obj/structure/table,
-/obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stock_parts/cell,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/mecha_part_fabricator,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "Fa" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -5378,7 +5392,6 @@
 /turf/closed/wall,
 /area/station/command/meeting_room)
 "Fe" = (
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
@@ -5451,17 +5464,15 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/gravity_generator)
 "FA" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "FD" = (
 /obj/machinery/autolathe,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "FL" = (
 /turf/closed/wall/rust,
 /area/station/commons/dorms)
@@ -5516,13 +5527,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "Gd" = (
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/cable,
-/obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/structure/closet/toolcloset,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "Ge" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5624,6 +5632,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/command/storage/eva)
+"GI" = (
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall,
+/area/station/medical/pharmacy)
 "GJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -5631,6 +5643,7 @@
 "GK" = (
 /obj/machinery/keycard_auth/directional/east,
 /obj/machinery/modular_computer/console/preset/id,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "GL" = (
@@ -5656,7 +5669,7 @@
 /obj/machinery/door/airlock{
 	name = "Bar"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "GP" = (
@@ -5816,9 +5829,9 @@
 /turf/open/floor/iron/white,
 /area/station/pathfinders/pathfinders_armory)
 "HD" = (
-/obj/structure/closet/wardrobe/white,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
 "HE" = (
@@ -5832,8 +5845,8 @@
 "HI" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "HJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5901,7 +5914,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "Ib" = (
 /turf/closed/wall/r_wall,
 /area/station/service/kitchen/diner)
@@ -5921,8 +5934,8 @@
 "Ig" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/circuit/red,
+/area/station/science/robotics/lab)
 "Ik" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/structure/cable,
@@ -6038,6 +6051,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"IJ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "bearcat_maintroom"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plating,
+/area/station/commons/vacant_room)
 "IK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -6062,7 +6082,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "IO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6346,13 +6366,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"KA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/aft/lesser)
 "KE" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -6445,6 +6458,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "La" = (
@@ -6484,7 +6498,15 @@
 /area/station/cargo/warehouse)
 "Lm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/clothing/deluxe,
+/obj/machinery/button/door/directional/west{
+	id = "bearcat_maintdoor";
+	name = "Commissary Door"
+	},
+/obj/machinery/button/door/directional/north{
+	name = "Commissary Shutters";
+	id = "bearcat_maintroom"
+	},
+/obj/structure/closet/wardrobe/white,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
 "Lp" = (
@@ -6528,10 +6550,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage)
 "Ly" = (
-/obj/structure/chair/stool,
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/dorms/barracks)
 "Lz" = (
@@ -6545,17 +6569,15 @@
 /turf/open/floor/plating,
 /area/station/pathfinders)
 "LB" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen Cold Room"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/airlock/freezer,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "LC" = (
@@ -6732,8 +6754,8 @@
 /area/station/hallway/primary/fore)
 "MB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/circuit/red,
+/area/station/science/robotics/lab)
 "MC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -6745,14 +6767,13 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/item/multitool,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "MG" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/closed/wall,
+/area/station/engineering/main)
 "MH" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
@@ -7166,7 +7187,9 @@
 "OO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/office/light,
 /obj/item/target,
+/obj/item/restraints/handcuffs/cable/yellow,
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
 "OP" = (
@@ -7459,8 +7482,9 @@
 "Qv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "Qw" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -7612,14 +7636,12 @@
 /turf/closed/wall/r_wall,
 /area/station/security)
 "Rl" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Hydroponics"
-	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/machinery/door/airlock/hydroponics/glass,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "Rm" = (
@@ -7662,7 +7684,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "Rw" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7679,6 +7700,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal)
+"Rz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
 "RC" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -7868,10 +7895,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/port)
 "Sx" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/freezer,
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
 "Sy" = (
@@ -7963,9 +7988,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "Ta" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -7977,9 +8001,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "Tc" = (
-/obj/machinery/smartfridge/organ,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "Tg" = (
 /obj/machinery/processor,
@@ -7996,8 +8023,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "Tm" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8053,7 +8080,6 @@
 "TB" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "TC" = (
@@ -8064,7 +8090,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
-/area/station/construction/storage_wing)
+/area/station/science/robotics/lab)
 "TE" = (
 /obj/structure/supplies_box/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -8284,7 +8310,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/maintenance/aft/lesser)
+/area/station/engineering/main)
 "UK" = (
 /obj/structure/sink{
 	pixel_y = 12
@@ -8588,9 +8614,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "WH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
@@ -8774,7 +8797,7 @@
 /area/station/hallway/primary/central/port)
 "XK" = (
 /turf/closed/wall/r_wall,
-/area/station/construction/storage_wing)
+/area/station/science/robotics/lab)
 "XM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 6
@@ -8785,15 +8808,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"XN" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall,
-/area/station/medical/medbay)
 "XP" = (
-/obj/machinery/vending/tool,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/construction/storage_wing)
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "XQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall,
@@ -8961,9 +8980,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "YU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "YV" = (
@@ -9027,6 +9044,12 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"Zi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "Zn" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -105952,8 +105975,8 @@ yz
 XF
 fv
 XI
-oE
-BR
+XF
+pc
 FD
 hr
 eO
@@ -106449,7 +106472,7 @@ NK
 QZ
 Ah
 QZ
-Se
+Qz
 lk
 zm
 iv
@@ -106467,12 +106490,12 @@ Jm
 Se
 Fl
 XF
-BR
-nQ
-xQ
+gx
+MG
+gx
 tn
 MG
-XK
+DJ
 NK
 NK
 NK
@@ -106716,7 +106739,7 @@ jV
 ta
 uM
 rS
-uh
+ar
 uh
 dP
 fs
@@ -106724,12 +106747,12 @@ lM
 dM
 jY
 XF
-pc
+UH
 Gd
 Bx
-Av
+vr
 HI
-XK
+DJ
 NK
 NK
 NK
@@ -106981,12 +107004,12 @@ YT
 dM
 jY
 fv
-BR
-BR
-BR
+UH
+mu
+eD
 sY
 BR
-XK
+DJ
 NK
 NK
 NK
@@ -107220,7 +107243,7 @@ NK
 QZ
 Ah
 Ah
-Qz
+Se
 ho
 aR
 ID
@@ -107238,12 +107261,12 @@ qz
 Se
 YX
 fv
-Cv
+gx
 FA
 Ia
-oh
+sY
 eX
-il
+DJ
 NK
 NK
 NK
@@ -107495,10 +107518,10 @@ JU
 Se
 NF
 hg
-Cv
+gx
 eQ
 nU
-KA
+vr
 IN
 UH
 NK
@@ -107991,7 +108014,7 @@ NK
 QZ
 Fg
 lD
-fP
+Se
 lD
 Se
 JU
@@ -108003,7 +108026,7 @@ iQ
 Lr
 iP
 iP
-iP
+Rz
 Ob
 He
 dM
@@ -108773,7 +108796,7 @@ qe
 BN
 bQ
 Dq
-qf
+bQ
 OX
 bQ
 bQ
@@ -109030,12 +109053,12 @@ uI
 vE
 NH
 NH
-zz
+NH
 NH
 NH
 Fp
 on
-Fp
+IJ
 Fp
 Lw
 Lw
@@ -109285,7 +109308,7 @@ kr
 Ce
 FP
 Ov
-NH
+lx
 Ly
 gu
 AE
@@ -110312,7 +110335,7 @@ aM
 ob
 vl
 aM
-aM
+Cr
 qb
 qb
 qb
@@ -110569,8 +110592,8 @@ aM
 aM
 aM
 aM
-NK
-NK
+aM
+qb
 NK
 NK
 NK
@@ -170980,7 +171003,7 @@ sG
 JT
 Uu
 qs
-wc
+Zi
 JE
 Gk
 Gk
@@ -174558,8 +174581,8 @@ dL
 sZ
 oq
 sZ
-sZ
-XN
+GI
+wz
 NI
 GR
 Zd
@@ -174815,7 +174838,7 @@ dL
 uP
 Ix
 SN
-sZ
+xB
 qX
 Hm
 AN
@@ -175073,7 +175096,7 @@ LN
 zH
 OT
 Tc
-di
+YU
 YU
 XU
 Uk
@@ -175330,7 +175353,7 @@ AK
 Mn
 dY
 lP
-YU
+di
 WH
 Hw
 Pu
@@ -175587,7 +175610,7 @@ dD
 DM
 qS
 mS
-Cs
+di
 aB
 XH
 tX
@@ -176105,8 +176128,8 @@ HT
 HT
 HT
 sX
-AC
-AC
+HT
+HT
 AC
 NK
 NK

--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -886,7 +886,7 @@
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "eS" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/table/reinforced,
@@ -906,7 +906,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "fc" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -2177,7 +2177,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "mv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -2450,7 +2450,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "nV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -3200,7 +3200,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "rV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3355,7 +3355,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "sZ" = (
 /turf/closed/wall,
 /area/station/medical/pharmacy)
@@ -3411,7 +3411,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "tr" = (
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 1
@@ -4807,7 +4807,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "BC" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron,
@@ -4874,7 +4874,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/circuit,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "BT" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -5184,7 +5184,7 @@
 /area/station/security)
 "DJ" = (
 /turf/closed/wall/r_wall,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "DK" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit,
@@ -5514,7 +5514,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "FD" = (
 /obj/machinery/autolathe,
 /turf/open/floor/iron/dark,
@@ -5580,7 +5580,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "Ge" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5881,7 +5881,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "HJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5949,7 +5949,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "Ib" = (
 /turf/closed/wall/r_wall,
 /area/station/service/kitchen)
@@ -6080,7 +6080,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "IH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6128,7 +6128,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "IO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6555,6 +6555,9 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plating,
 /area/station/commons/vacant_room)
+"Ln" = (
+/turf/closed/wall,
+/area/station/engineering/lobby)
 "Lp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6821,7 +6824,7 @@
 "MG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "MH" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
@@ -7353,6 +7356,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"Pm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/engineering/lobby)
 "Pn" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -8391,7 +8401,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/engineering/lobby)
 "UK" = (
 /obj/structure/sink{
 	pixel_y = 12
@@ -106592,9 +106602,9 @@ Jm
 Se
 Fl
 XF
-gx
+Ln
 MG
-gx
+Ln
 tn
 MG
 DJ
@@ -106852,7 +106862,7 @@ XF
 UH
 Gd
 Bx
-vr
+Pm
 HI
 DJ
 NK
@@ -107363,7 +107373,7 @@ qz
 Se
 YX
 fv
-gx
+Ln
 FA
 Ia
 IG
@@ -107620,10 +107630,10 @@ JU
 Se
 NF
 hg
-gx
+Ln
 eQ
 nU
-vr
+Pm
 IN
 UH
 NK

--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -15,11 +15,6 @@
 ///Paygrade for Heads of Staff.
 #define PAYCHECK_COMMAND 100
 
-//How many credits a player is charged if they print something from a departmental lathe they shouldn't have access to.
-#define LATHE_TAX 10
-//How much POWER a borg's cell is taxed if they print something from a departmental lathe.
-#define SILICON_LATHE_TAX 2000
-
 #define STATION_TARGET_BUFFER 25
 
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -239,9 +239,6 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/rnd/production/protolathe/department/engineering
 
-/obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	build_path = /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
-
 /obj/item/circuitboard/machine/rtg
 	name = "RTG"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -29,9 +29,6 @@
 	/// What color is this machine's stripe? Leave null to not have a stripe.
 	var/stripe_color = null
 
-	/// Does this charge the user's ID on fabrication?
-	var/charges_tax = TRUE
-
 /obj/machinery/rnd/production/Initialize(mapload)
 	. = ..()
 
@@ -280,36 +277,6 @@
 		if(!reagents.has_reagent(reagent, design.reagents_list[reagent] * print_quantity * coefficient))
 			say("Not enough reagents to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
-
-	// Charge the lathe tax at least once per ten items.
-	var/total_cost = LATHE_TAX * max(round(print_quantity / 10), 1)
-
-	if(!charges_tax)
-		total_cost = 0
-
-	if(isliving(usr))
-		var/mob/living/user = usr
-		var/obj/item/card/id/card = user.get_idcard(TRUE)
-
-		if(!card && istype(user.pulling, /obj/item/card/id))
-			card = user.pulling
-
-		if(card && card.registered_account)
-			var/datum/bank_account/our_acc = card.registered_account
-			if(our_acc.account_job.departments_bitflags & allowed_department_flags)
-				total_cost = 0 // We are not charging crew for printing their own supplies and equipment.
-
-	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)
-		say("Insufficient funds to complete prototype. Please present a holochip or valid ID card.")
-		return FALSE
-
-	if(iscyborg(usr))
-		var/mob/living/silicon/robot/borg = usr
-
-		if(!borg.cell)
-			return FALSE
-
-		borg.cell.use(SILICON_LATHE_TAX)
 
 	materials.mat_container.use_materials(efficient_mats, print_quantity)
 	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats)

--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -21,4 +21,3 @@
 	desc = "Manufactures circuit boards for the construction of machines. Its ancient construction may limit its ability to print all known technology."
 	allowed_buildtypes = AWAY_IMPRINTER
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation
-	charges_tax = FALSE

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -12,10 +12,6 @@
 	stripe_color = "#EFB341"
 	payment_department = ACCOUNT_ENG
 
-/obj/machinery/rnd/production/protolathe/department/engineering/no_tax
-	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	charges_tax = FALSE
-
 /obj/machinery/rnd/production/protolathe/department/service
 	name = "department protolathe (Service)"
 	allowed_department_flags = DEPARTMENT_BITFLAG_SERVICE

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -23,4 +23,3 @@
 	desc = "Converts raw materials into useful objects. Its ancient construction may limit its ability to print all known technology."
 	circuit = /obj/item/circuitboard/machine/protolathe/offstation
 	allowed_buildtypes = AWAY_LATHE
-	charges_tax = FALSE


### PR DESCRIPTION
## About The Pull Request

While local testing other PRs, I had a laundry list of gripes on how you both navigate and play certain jobs on the Bearcat. Let's make it far less painful to play certain jobs and navigate the ship in general.

- Bar, kitchen and hydroponics now only use general service access. You'll still want the job-specific accesses for the vendor discounts, though.
- Botany now has a direct door to the kitchen.
- Medbay's design has been made more sane, stealing some design tricks from botany/kitchen.
- Gave the chemist a crowbar.
- Fixed some overlapping lights/switches/apcs/radios/signs.
- Removed a couple of railings from the middle deck to make navigation from the elevator easier.
- The bunks door has been moved to the dorms corridor, better hinting to the room's purpose.
- The clothesmate has been moved to the dorms corridor.
- The dorms corridor now has signage and a named airlock.
- The spare room has been refitted to also work as a commissary.
- Robotics has been properly implemented as a room, and the weird engineering maintenance shaft has been resized and refitted to be the engi lathe room.
- Added a set of zip-ties and a chair to the firing range for... reasons.
- Added an extra space heater and portable scrubber to the SMES room.
- The bar and kitchen now take up most of the upper deck, for your bar-RP needs.
- Janitors will now find they actually have equipment.
- Fixed the command hallway having no lighting.
- Removed command access from EVA.
- Oh, and also added a donksoft vendor.

# Oh, and I removed that fucking lathe tax while I was at it.

## How Does This Help ***Gameplay***?

Makes Bearcat feel a little more feature complete!

Also robotocists now aren't left without a place to call home.

Also janitors have the stuff to do their job.

## How Does This Help ***Roleplay***?

The ship feels a little more believable!

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/e52f8d35-348e-48e6-a481-09e8012afe7c)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/f438c6cc-335c-450b-8aaa-15ad92a96481)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/8326f98f-5629-4d70-abe2-14716812708b)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/92614b20-ead5-4bd3-804d-af8c34448682)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Bearcat's service and engineering wings got a partial rework.
qol: Miscellaneous Bearcat improvements, see PR 340 for precise details.
qol: Yeeted that damn lathe tax.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
