### PR TITLE
Reverse Lift Button Display Order

### DIFF
--- a/tgui/packages/tgui/interfaces/ElevatorPanel.tsx
+++ b/tgui/packages/tgui/interfaces/ElevatorPanel.tsx
@@ -26,23 +26,25 @@ export const ElevatorPanel = (props, context) => {
       <Window.Content>
         <Section title="Select Floor" textAlign="center">
           <Stack vertical>
-            {data.floors.map((entry) => {
-              return (
-                <Stack.Item grow key={entry.id} mb="4em">
-                  <Button
-                    content={entry.name}
-                    textAlign="center"
-                    fontSize="1.2em"
-                    fluid={1}
-                    lineHeight="3"
-                    onClick={() =>
-                      act('task', { task: 'click_waypoint', id: entry.id })
-                    }
-                    color={entry.is_active ? 'green' : null}
-                  />
-                </Stack.Item>
-              );
-            })}
+            {data.floors
+              .map((entry) => {
+                return (
+                  <Stack.Item grow key={entry.id} mb="4em">
+                    <Button
+                      content={entry.name}
+                      textAlign="center"
+                      fontSize="1.2em"
+                      fluid={1}
+                      lineHeight="3"
+                      onClick={() =>
+                        act('task', { task: 'click_waypoint', id: entry.id })
+                      }
+                      color={entry.is_active ? 'green' : null}
+                    />
+                  </Stack.Item>
+                );
+              })
+              .reverse()}
             <Stack.Item grow mb="3.4em">
               <Button
                 content="STOP"


### PR DESCRIPTION
## About The Pull Request

Tin. I kept forgetting to do this, and now I've remembered.

PR to fix the elevator feedback issues coming separately. I've a splitting headache for two days now.

## How Does This Help ***Gameplay***?

Makes it far less confusing what way the elevator's gonna go!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/89cb0cba-b613-4f1c-8c20-8268c7eb45c6)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Elevator buttons now display in order relative to floors.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
