### PR TITLE
Make Vendors Show Returns as Free

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -954,6 +954,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 			name = product_record.name,
 			amount = product_record.amount,
 			colorable = product_record.colorable,
+			free = !!product_record.returned_products,
 		)
 
 		.["stock"][product_record.name] = product_data

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -1,4 +1,4 @@
-import { classes } from 'common/react';
+import { BooleanLike, classes } from 'common/react';
 import { capitalizeAll } from 'common/string';
 import { useBackend, useLocalState } from 'tgui/backend';
 import { Box, Button, Icon, LabeledList, NoticeBox, Section, Stack, Table } from 'tgui/components';
@@ -51,6 +51,7 @@ type StockItem = {
   name: string;
   amount: number;
   colorable: boolean;
+  free: BooleanLike;
 };
 
 type CustomInput = {
@@ -222,7 +223,7 @@ const VendingRow = (props, context) => {
   const { data } = useBackend<VendingData>(context);
   const { custom, product, productStock } = props;
   const { access, department, jobDiscount, onstation, user } = data;
-  const free = !onstation || product.price === 0;
+  const free = !onstation || product.price === 0 || productStock.free;
   const discount = !product.premium && department === user?.department;
   const remaining = custom ? product.amount : productStock.amount;
   const redPrice = Math.round(product.price * jobDiscount);


### PR DESCRIPTION
## About The Pull Request

Tin.

Fixes #366 

## How Does This Help ***Gameplay***?

Now you aren't caught off by returns that are in the machine!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/ae192960-7145-47fa-a70d-e56f8002ceff)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/c52280ad-5b5f-410b-872d-c30d8adc8ecc)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Vendors now actually show they have a free returned item.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
