### PR TITLE
[PORT] Stop, Drop, Roll QoL Improvements!

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -290,13 +290,17 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/fire/Click()
 	. = ..()
 	if(!.)
-		return
+		return FALSE
 
 	var/mob/living/living_owner = owner
+	if(!living_owner.can_resist())
+		return FALSE
 
 	living_owner.changeNext_move(CLICK_CD_RESIST)
-	if(living_owner.mobility_flags & MOBILITY_MOVE)
-		return living_owner.resist_fire()
+	if(!(living_owner.mobility_flags & MOBILITY_MOVE))
+		return FALSE
+
+	return living_owner.resist_fire()
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"

--- a/code/datums/status_effects/buffs/stop_drop_roll.dm
+++ b/code/datums/status_effects/buffs/stop_drop_roll.dm
@@ -1,0 +1,66 @@
+/datum/status_effect/stop_drop_roll
+	id = "stop_drop_roll"
+	alert_type = null
+
+	tick_interval = 0.8 SECONDS
+
+/datum/status_effect/stop_drop_roll/on_apply()
+	if(!iscarbon(owner))
+		return FALSE
+
+	var/actual_interval = initial(tick_interval)
+	if(!owner.Knockdown(actual_interval * 2, ignore_canstun = TRUE) || owner.body_position != LYING_DOWN)
+		to_chat(owner, span_warning("You try to stop, drop, and roll - but you can't get on the ground!"))
+		return FALSE
+
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(stop_rolling))
+	RegisterSignal(owner, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(body_position_changed))
+	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, id) // they're kinda busy!
+
+	owner.visible_message(
+		span_danger("[owner] rolls on the floor, trying to put [owner.p_them()]self out!"),
+		span_notice("You stop, drop, and roll!"),
+	)
+	// Start with one weaker roll
+	owner.spin(spintime = actual_interval, speed = actual_interval / 4)
+	owner.adjust_fire_stacks(-0.25)
+	return TRUE
+
+/datum/status_effect/stop_drop_roll/on_remove()
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_BODY_POSITION))
+	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, id)
+
+/datum/status_effect/stop_drop_roll/tick(seconds_between_ticks)
+	if(HAS_TRAIT(owner, TRAIT_IMMOBILIZED) || HAS_TRAIT(owner, TRAIT_INCAPACITATED))
+		qdel(src)
+		return
+
+	var/actual_interval = initial(tick_interval)
+	if(!owner.Knockdown(actual_interval * 1.2, ignore_canstun = TRUE))
+		stop_rolling()
+		return
+
+	owner.spin(spintime = actual_interval, speed = actual_interval / 4)
+	owner.adjust_fire_stacks(-1)
+
+	if(owner.fire_stacks > 0)
+		return
+
+	owner.visible_message(
+		span_danger("[owner] successfully extinguishes [owner.p_them()]self!"),
+		span_notice("You extinguish yourself."),
+	)
+	qdel(src)
+
+/datum/status_effect/stop_drop_roll/proc/stop_rolling(datum/source, ...)
+	SIGNAL_HANDLER
+
+	if(!QDELING(owner))
+		to_chat(owner, span_notice("You stop rolling around."))
+	qdel(src)
+
+/datum/status_effect/stop_drop_roll/proc/body_position_changed(datum/source, new_value, old_value)
+	SIGNAL_HANDLER
+
+	if(new_value != LYING_DOWN)
+		stop_rolling()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -263,16 +263,7 @@
 		buckled.user_unbuckle_mob(src,src)
 
 /mob/living/carbon/resist_fire()
-	adjust_fire_stacks(-5)
-	Paralyze(60, ignore_canstun = TRUE)
-	spin(32,2)
-	visible_message(span_danger("[src] rolls on the floor, trying to put [p_them()]self out!"), \
-		span_notice("You stop, drop, and roll!"))
-	sleep(30)
-	if(fire_stacks <= 0 && !QDELETED(src))
-		visible_message(span_danger("[src] successfully extinguishes [p_them()]self!"), \
-			span_notice("You extinguish yourself."))
-	return
+	return !!apply_status_effect(/datum/status_effect/stop_drop_roll)
 
 /mob/living/carbon/resist_restraints()
 	var/obj/item/I = null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1064,7 +1064,7 @@
 	buckled.user_unbuckle_mob(src,src)
 
 /mob/living/proc/resist_fire()
-	return
+	return FALSE
 
 /mob/living/proc/resist_restraints()
 	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1246,6 +1246,7 @@
 #include "code\datums\status_effects\song_effects.dm"
 #include "code\datums\status_effects\stacking_effect.dm"
 #include "code\datums\status_effects\wound_effects.dm"
+#include "code\datums\status_effects\buffs\stop_drop_roll.dm"
 #include "code\datums\status_effects\debuffs\choke.dm"
 #include "code\datums\status_effects\debuffs\confusion.dm"
 #include "code\datums\status_effects\debuffs\debuffs.dm"


### PR DESCRIPTION
## About The Pull Request

Stolen from https://github.com/tgstation/tgstation/pull/79694

So yeah, melbert's been on a bit of a roll with QoL stuff on TG, but this is something I especially want!

tl;dr, you can now get up mid-rolling if needed! It is interrupted if you're moved by any means, though, which could be a problem, but we can always change that if need be!

## How Does This Help ***Gameplay***?

Less stun-based gameplay!

Also no more having to stop-drop-roll multiple times if you're caught on fire by lava! Wooo!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->


https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/89687c96-da68-4b3b-973b-a318dff80c4d

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: MrMelbert (TG), RimiNosha
qol: Stop, drop and roll has been reworked to be interruptible, and continue until you're fully extinguished!
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
