### PR TITLE
Bodies Can No Longer Be Easily Superheated

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -78,6 +78,9 @@
 /// The temperature the blue icon is displayed.
 #define BODYTEMP_COLD_WARNING_3 (BODYTEMP_COLD_DAMAGE_LIMIT - 150) //120k
 
+/// Beyond this temperature, being on fire will increase body temperature by less and less
+#define BODYTEMP_FIRE_TEMP_SOFTCAP 1200
+
 /// The amount of pressure damage someone takes is equal to (pressure / HAZARD_HIGH_PRESSURE)*PRESSURE_DAMAGE_COEFFICIENT, with the maximum of MAX_PRESSURE_DAMAGE
 #define PRESSURE_DAMAGE_COEFFICIENT 2
 #define MAX_HIGH_PRESSURE_DAMAGE 2

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -197,14 +197,19 @@
 	var/mob/living/carbon/human/victim = owner
 	var/thermal_protection = victim.get_thermal_protection()
 
-	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT && !no_protection)
-		return
+	if(!no_protection)
+		if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
+			return
+		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
+			victim.adjust_bodytemperature(5.5 * seconds_per_tick)
+			return
 
-	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
-		victim.adjust_bodytemperature(5.5 * delta_time)
-		return
+	var/amount_to_heat = (BODYTEMP_HEATING_MAX + (stacks * 12)) * 0.5 * delta_time
+	if(owner.bodytemperature > BODYTEMP_FIRE_TEMP_SOFTCAP)
+		// Apply dimishing returns upon temp beyond the soft cap
+		amount_to_heat = amount_to_heat ** (BODYTEMP_FIRE_TEMP_SOFTCAP / owner.bodytemperature)
 
-	victim.adjust_bodytemperature((BODYTEMP_HEATING_MAX + (stacks * 12)) * 0.5 * delta_time)
+	victim.adjust_bodytemperature(amount_to_heat)
 	victim.add_mood_event("on_fire", /datum/mood_event/on_fire)
 	victim.mind?.add_memory(MEMORY_FIRE, list(DETAIL_PROTAGONIST = victim), story_value = STORY_VALUE_OKAY)
 

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -201,7 +201,7 @@
 		if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
 			return
 		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT)
-			victim.adjust_bodytemperature(5.5 * seconds_per_tick)
+			victim.adjust_bodytemperature(5.5 * delta_time)
 			return
 
 	var/amount_to_heat = (BODYTEMP_HEATING_MAX + (stacks * 12)) * 0.5 * delta_time


### PR DESCRIPTION
## About The Pull Request

Tin. Basically, lava and plasma fires have a terrible tendency to superheat people to several times hotter than the sun. Let's uh, not do that.

Bodies typically cremate at 1200k, so it makes entirely no sense.

Stolen from https://github.com/tgstation/tgstation/pull/79655

## How Does This Help ***Gameplay***?

You aren't dying from heat for two hours straight after having an incident with lava.

## How Does This Help ***Roleplay***?

This uh, isn't physically possible.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/37e0652e-b214-406d-9e0b-d125accca436)
Seconds before cremation.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fires can no longer superheat a body (living or dead) to hotter-than-the-sun temperatures.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
