### PR TITLE
Removes 2/3rds of The Astrum's Thrusters

### DIFF
--- a/_maps/shuttles/pathfinders_astrum.dmm
+++ b/_maps/shuttles/pathfinders_astrum.dmm
@@ -36,7 +36,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "eu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
@@ -163,7 +162,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "oy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/door/airlock/command/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -175,7 +173,6 @@
 /turf/open/space/basic,
 /area/space)
 "oP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -284,7 +281,6 @@
 /turf/open/floor/plating,
 /area/shuttle/overmap/aev_p/astrum)
 "zL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
@@ -294,6 +290,11 @@
 "zY" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/overmap/aev_p/astrum)
+"Ap" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "As" = (
@@ -309,7 +310,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "Az" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -336,7 +336,6 @@
 /turf/open/floor/plating,
 /area/shuttle/overmap/aev_p/astrum)
 "Gg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/button/door/directional/south{
 	id = "astrum_oh_shit_button";
 	name = "Window Shutters"
@@ -355,7 +354,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "Hu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -393,13 +391,6 @@
 /obj/machinery/door/airlock/public,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/overmap/aev_p/astrum)
-"JZ" = (
-/obj/machinery/atmospherics/components/unary/engine{
-	dir = 8;
-	pixel_x = -8
-	},
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/overmap/aev_p/astrum)
 "Kj" = (
 /turf/closed/wall/mineral/titanium,
@@ -461,7 +452,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "OI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -483,13 +473,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
-"Rg" = (
-/obj/machinery/atmospherics/components/unary/engine{
-	pixel_x = 8;
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/overmap/aev_p/astrum)
 "RS" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -497,7 +480,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "RW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -532,7 +514,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "UN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -553,7 +534,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "Wo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -578,7 +558,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/overmap/aev_p/astrum)
 "Yf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -595,6 +574,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/pathfinders/dock,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
+/area/shuttle/overmap/aev_p/astrum)
+"YS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/shuttle/overmap/aev_p/astrum)
 "YT" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
@@ -673,7 +656,7 @@ oG
 YT
 YT
 Kj
-JZ
+Kj
 Kj
 Kj
 Kj
@@ -684,7 +667,7 @@ YT
 Kj
 Kj
 Kj
-JZ
+Kj
 Kj
 WE
 "}
@@ -694,7 +677,7 @@ YT
 YT
 fJ
 At
-IO
+YS
 Kj
 rY
 EH
@@ -756,7 +739,7 @@ oG
 YT
 YT
 Ku
-xO
+Ap
 UN
 Kj
 OO
@@ -800,9 +783,9 @@ YT
 Xj
 zL
 Yf
-xO
+Ap
 Az
-xO
+Ap
 Hu
 dF
 lK
@@ -904,7 +887,7 @@ YT
 YT
 xZ
 Nm
-IO
+YS
 Kj
 uo
 Mf
@@ -925,7 +908,7 @@ DU
 Kj
 Kj
 Kj
-Rg
+Kj
 Kj
 Kj
 Kj
@@ -936,7 +919,7 @@ YT
 Kj
 Kj
 Kj
-Rg
+Kj
 Kj
 WE
 "}


### PR DESCRIPTION
## About The Pull Request

Shit was like teleporting. Let's uh, not do that.

Fixes #358

## How Does This Help ***Gameplay***?

Pathies are a little more reliant on the ship once more.

## How Does This Help ***Roleplay***?

Travel talk, or something.

## Proof of Testing

See MDB.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: The Astrum (new pathies shuttle) has had it's engines reduced to sane levels.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
