### PR TITLE
Fix Shuttle Viewers Having Their View Set Incrorrectly

### DIFF
--- a/code/modules/overmap/shuttle_control_component.dm
+++ b/code/modules/overmap/shuttle_control_component.dm
@@ -90,7 +90,7 @@
 /datum/overmap_shuttle_controller/proc/RemoveViewer(mob/our_guy)
 	UnregisterSignal(our_guy, COMSIG_CLICKON)
 	our_guy.client.perspective = MOB_PERSPECTIVE
-	our_guy.client.eye = mob_controller
+	our_guy.client.eye = our_guy
 	our_guy.client.show_popup_menus = TRUE
 	our_guy.client.pixel_x = 0
 	our_guy.client.pixel_y = 0


### PR DESCRIPTION
## About The Pull Request

Yup, it was as I thought, except this is just if they close the console at all, not if the shuttle controller leaves. Woops.

Fixes #353

## How Does This Help ***Gameplay***?

Fix bug good.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/dd07279d-4029-4b6e-8f2b-e9d08c92801b


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Shuttle viewers will no longer have their view broken on closing their UI.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
