### PR TITLE
Fix Renaming Captain's Spare ID Not Updating Text, Remove Extra Typing Sounds

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -172,7 +172,6 @@
 
 			if(!new_name)
 				inserted_auth_card.registered_name = null
-				playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 				inserted_auth_card.update_label()
 				// We had a name before and now we have no name, so this will unassign the card and we update the icon.
 				if(old_name)
@@ -187,10 +186,9 @@
 				return TRUE
 
 			inserted_auth_card.registered_name = new_name
-			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 			inserted_auth_card.update_label()
 			// Card wasn't assigned before and now it is, so update the icon accordingly.
-			if(!old_name)
+			if(!old_name || old_name == "Captain")
 				inserted_auth_card.update_icon()
 			return TRUE
 		// Change age
@@ -204,7 +202,6 @@
 				return TRUE
 
 			inserted_auth_card.registered_age = new_age
-			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 			return TRUE
 		// Change assignment
 		if("PRG_assign")
@@ -212,14 +209,12 @@
 				return TRUE
 			var/new_asignment = sanitize(params["assignment"])
 			inserted_auth_card.assignment = new_asignment
-			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 			inserted_auth_card.update_label()
 			return TRUE
 		// Add/remove access.
 		if("PRG_access")
 			if(!computer || !authenticated_card || !inserted_auth_card)
 				return TRUE
-			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 			var/access_type = params["access_target"]
 			var/try_wildcard = params["access_wildcard"]
 			if(!(access_type in valid_access))
@@ -245,7 +240,6 @@
 			if(!computer || !authenticated_card || !inserted_auth_card)
 				return TRUE
 
-			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
 			var/template_name = params["name"]
 
 			if(!template_name)


### PR DESCRIPTION
## About The Pull Request

Tin. Typing on the computer/pda was a little weird, and it was cause I forgot to remove the old sound typing sound sources.

Fixes #362

## How Does This Help ***Gameplay***?

Less audio weirdness, captain's spare looks correct now.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/19a4b94f-bc3d-41e3-82da-cb4e639ffcc3)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/fb3f516d-4ece-482f-8af3-bfc4f9899f80)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/3c95cef3-3a01-40a0-af0a-8d382e8051a5)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed captain's spare never gaining it's text on it's icon.
fix: Fixed the access management program playing extra typing sounds when it shouldn't be.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
