### PR TITLE
Remove Shift Start Auto Blue Alert + Renames Central Command to Corporate

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -21,7 +21,7 @@ GLOBAL_VAR(command_name)
 	if (GLOB.command_name)
 		return GLOB.command_name
 
-	var/name = "Central Command"
+	var/name = "Corporate"
 
 	GLOB.command_name = name
 	return name

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -335,12 +335,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	. += generate_station_trait_report()
 
 	print_command_report(., "[command_name()] Status Summary", announce=FALSE)
-	if(greenshift)
-		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", SSstation.announcer.get_rand_report_sound())
-	else
-		priority_announce("A summary has been copied and printed to all communications consoles.", "Security level elevated.", ANNOUNCER_INTERCEPT)
-		if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_BLUE)
-			SSsecurity_level.set_level(SEC_LEVEL_BLUE)
+	minor_announce("A summary has been copied and printed to all communications consoles.", "[command_name()] Update", color_override = "blue")
 
 /datum/game_mode/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())


### PR DESCRIPTION
## About The Pull Request

Cope + Lore + MY FUCKING EARS, WHY IS THIS BLARE WORTHY?!

Anyways. Tin.

<!-- SEE THE CONTRIBUTING GUIDELINES AND ESPECIALLY THE FOLLOWING BEFORE MAKING A PR: https://github.com/Artea-Station/Artea-Station-Server/blob/master/.github/guides/RESTRICTED_PR_TOPICS.md -->

## How Does This Help ***Gameplay***?

The round start blue elevation reason is just not true. Let's not immediately tell the crew they've got enemies they don't actually have.

## How Does This Help ***Roleplay***?

Finally getting around to calling central command corportate instead.

## Proof of Testing

Uhhhh, see playtest, it's like an hour away.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
spellcheck: Central Command > Corporate
tweak: The roundstart report no longer elevates security level to blue.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
