### PR TITLE
Makes the produce order console board printable

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -385,3 +385,13 @@
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_RECORDS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/board/chef_order
+	name = "Produce Orders Console"
+	desc = "An interface for ordering fresh produce and other. A far more expensive option than the botanists, but oh well."
+	id = "chef_order_console"
+	build_path = /obj/item/circuitboard/computer/chef_order
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ENTERTAINMENT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -933,6 +933,7 @@
 		"mining",
 		"rdcamera",
 		"seccamera",
+		"chef_order_console",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 


### PR DESCRIPTION
## About The Pull Request
Fixes #400 

Produce order console can now be researched and printed at the service lathe. It was kinda stupid this thing wasn't printable from the start but it is now.

## How Does This Help ***Gameplay***?
Service now has access to stuff thats locked behind this console (Pickles and other stuff)

## How Does This Help ***Roleplay***?
No Impact on RP.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/15aba0b2-58a1-48c5-81f1-38938fcb9591)
 
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/d6a9537d-ecaa-410f-b4ce-f2993fcb30dd)


</details>

## Changelog
:cl:
add: Produce order console can now be printed on the service lathe.
/:cl: