### PR TITLE
Bearcat Mapping tweaks

### DIFF
--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -439,7 +439,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "cu" = (
-/obj/machinery/deepfryer,
 /obj/structure/sink{
 	pixel_y = 22
 	},
@@ -449,6 +448,7 @@
 	pixel_x = 6;
 	pixel_y = 40
 	},
+/obj/machinery/oven,
 /turf/open/floor/iron/kitchen/herringbone,
 /area/station/service/kitchen)
 "cv" = (
@@ -1470,10 +1470,6 @@
 /area/station/engineering/supermatter/room)
 "iy" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = 14;
-	pixel_y = 6
-	},
 /obj/machinery/reagentgrinder{
 	pixel_y = 7;
 	pixel_x = -5
@@ -3498,10 +3494,8 @@
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/pathfinders)
 "tE" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv{
-	pixel_x = 1;
-	pixel_y = 6
+/obj/machinery/computer/security{
+	dir = 8
 	},
 /turf/open/floor/iron/smooth,
 /area/station/command/meeting_room)
@@ -5641,6 +5635,7 @@
 /obj/structure/janitorialcart,
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
+/obj/item/storage/box/lights/mixed,
 /obj/item/lightreplacer,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
@@ -7561,15 +7556,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "PZ" = (
-/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/storage/book/bible/booze,
-/obj/item/clothing/glasses/regular/thin,
 /obj/machinery/light_switch/directional/north,
-/obj/item/clothing/head/kitty{
-	name = "crusty kitty ears";
-	pixel_y = 11
-	},
+/obj/machinery/computer/chef_order,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "Qb" = (
@@ -7832,12 +7821,13 @@
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
 "Rq" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv,
 /obj/machinery/button/door/directional/north{
 	id = "captainshutters";
 	name = "Shutters Control Button";
 	pixel_y = -26
+	},
+/obj/machinery/computer/security{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)


### PR DESCRIPTION
## About The Pull Request
Fixes #395 
The Deepfryer has been replaced with an oven 
This PR also adds a produce order console to the service hallway.
All Wooden security camera consoles have been replaced with their normal computer variant (Crumpaloo's request)

## How Does This Help ***Gameplay***?
Makes service gameplay easier since you start with the right machinery now.

## How Does This Help ***Roleplay***?
Minimal impact on RP.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/f82e7934-c741-4109-92a5-d9d4c5c96190)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/65158f62-23c6-4ea8-b7b3-6ae6c3848f8e)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/fce921ec-6c5c-4b9c-8cd0-8e51facd65cc)

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/2dc9d898-1916-47b0-89a6-3e863e1e10db)
(Bottom console on this screenshot)


</details>

## Changelog
:cl:
add: Added a produce order console to the service hallway on Bearcat
add: Replaced the deepfryer with an Oven on Bearcat.
code: Changed all wooden security camera consoles to be their normal computer variant on Bearcat.
/:cl: