### PR TITLE
[Port] Mech transport ruin update

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -1,340 +1,578 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"ah" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"ce" = (
+/obj/effect/decal/cleanable/glass/titanium,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"dq" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"dB" = (
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"dW" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"gK" = (
+/obj/structure/mecha_wreckage/ripley,
+/turf/open/floor/iron/recharge_floor/Airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"hq" = (
+/obj/item/stack/tile/iron/smooth,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"hR" = (
+/obj/item/shard/titanium,
 /turf/template_noop,
 /area/template_noop)
-"b" = (
-/turf/closed/wall/mineral/titanium/overspace,
-/area/ruin/space/has_grav/powered/mechtransport)
-"c" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/mechtransport)
-"d" = (
-/turf/closed/wall/mineral/titanium,
-/area/ruin/space/has_grav/powered/mechtransport)
-"f" = (
-/obj/structure/closet/crate/secure/loot,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/mineral/titanium/blue,
-/area/ruin/space/has_grav/powered/mechtransport)
-"g" = (
-/obj/structure/closet/crate/secure/loot,
-/turf/open/floor/mineral/titanium/blue,
-/area/ruin/space/has_grav/powered/mechtransport)
-"h" = (
+"if" = (
+/obj/structure/lattice,
+/obj/structure/mecha_wreckage/gygax,
+/turf/template_noop,
+/area/template_noop)
+"is" = (
+/turf/template_noop,
+/area/template_noop)
+"iT" = (
 /obj/structure/table,
 /obj/machinery/button/door{
 	id = "mechaship1";
 	name = "Mecha Cargo Ship Doors"
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"i" = (
+"jI" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"jZ" = (
+/obj/item/stack/tile/iron/smooth,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"kl" = (
+/obj/item/ammo_casing/spent{
+	dir = 9;
+	pixel_y = -9;
+	pixel_x = -10
+	},
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"ko" = (
+/obj/structure/mecha_wreckage/phazon,
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"kt" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/cup/glass/coffee_cup{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new,
+/turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"j" = (
+"kY" = (
+/obj/structure/lattice,
+/obj/item/ammo_casing/spent{
+	dir = 5;
+	pixel_y = -7;
+	pixel_x = 12
+	},
+/turf/template_noop,
+/area/template_noop)
+"lc" = (
+/obj/structure/lattice,
+/obj/item/stack/sheet/iron,
+/turf/template_noop,
+/area/template_noop)
+"lB" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wideplating_new,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"lP" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"mU" = (
 /obj/machinery/computer/shuttle{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"k" = (
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/mineral/titanium/blue,
+"nf" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"l" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/mineral/titanium/blue,
+"qH" = (
+/obj/structure/mecha_wreckage/durand,
+/turf/open/floor/iron/recharge_floor/Airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"m" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/blue,
-/area/ruin/space/has_grav/powered/mechtransport)
-"n" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/ruin/space/has_grav/powered/mechtransport)
-"p" = (
+"rD" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cockpit"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/iron/smooth_large/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"r" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/mineral/titanium/airless,
+"sv" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/iron/smooth_large/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"s" = (
-/turf/open/floor/mineral/titanium/airless,
+"sY" = (
+/turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"t" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"u" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/mineral/titanium/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"v" = (
-/obj/structure/mecha_wreckage/phazon,
-/turf/open/floor/mineral/titanium/yellow/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"w" = (
-/turf/open/floor/mineral/titanium/yellow/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"x" = (
+"uF" = (
 /obj/structure/mecha_wreckage/clarke,
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/iron/recharge_floor/Airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"y" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/yellow/airless,
+"uN" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/iron/smooth_large/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"z" = (
-/obj/structure/mecha_wreckage/ripley,
-/turf/open/floor/mineral/titanium/yellow/airless,
+"vJ" = (
+/obj/item/ammo_casing/spent{
+	dir = 5;
+	pixel_x = -12
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/iron/smooth_large/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"A" = (
-/obj/vehicle/sealed/mecha/working/ripley,
-/turf/open/floor/mineral/titanium/yellow/airless,
+"wJ" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"xJ" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mineral/titanium/blue/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"B" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/mineral/titanium/yellow/airless,
+"yr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron/stairs/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"C" = (
+"yT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Bl" = (
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 4;
+	name = "Broken Computer"
+	},
+/obj/machinery/light/broken/directional/west,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Ch" = (
+/obj/structure/marker_beacon/burgundy{
+	name = "landing marker"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Cy" = (
+/obj/item/stack/tile/iron/smooth,
+/obj/item/ammo_casing/spent{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"CT" = (
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"DD" = (
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"DM" = (
+/obj/structure/mecha_wreckage/odysseus,
+/turf/open/floor/iron/recharge_floor/Airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Ga" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Gy" = (
+/obj/structure/mecha_wreckage/odysseus,
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"GT" = (
+/obj/item/ammo_casing/spent{
+	pixel_y = -6;
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"HB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer4{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/titanium/Airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Il" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Kv" = (
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 4;
+	name = "Broken Computer"
+	},
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"KR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/turf/template_noop,
+/area/template_noop)
+"Lk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Mn" = (
 /obj/effect/decal/cleanable/robot_debris/up,
-/turf/open/floor/mineral/titanium/yellow/airless,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"D" = (
+"NG" = (
+/obj/vehicle/sealed/mecha/working/ripley,
+/turf/open/floor/iron/recharge_floor/Airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Oh" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Ov" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/catwalk_floor/iron_smooth/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"OJ" = (
+/turf/open/floor/iron/recharge_floor/Airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"PG" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"Qc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/titanium/Airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Ry" = (
+/obj/structure/closet/crate/secure/loot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Te" = (
+/obj/effect/decal/cleanable/robot_debris/up,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"WC" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"WN" = (
+/obj/effect/decal/cleanable/robot_debris/up,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"WX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Xe" = (
+/obj/machinery/computer/mecha{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/wideplating_new,
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Xs" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
+"XL" = (
 /obj/machinery/door/poddoor{
 	id = "mechaship1";
 	name = "Cargo Bay Door"
 	},
-/turf/open/floor/mineral/titanium/yellow/airless,
+/turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"E" = (
-/obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/mineral/titanium/yellow/airless,
+"XO" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/iron/smooth_large/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
-"F" = (
-/obj/structure/mecha_wreckage/durand,
-/turf/open/floor/mineral/titanium/yellow/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"G" = (
-/obj/item/stack/tile/iron/base,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"H" = (
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"I" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/ruin/space/has_grav/powered/mechtransport)
-"J" = (
-/obj/machinery/computer/mecha{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/ruin/space/has_grav/powered/mechtransport)
-"K" = (
-/obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"L" = (
-/obj/effect/decal/cleanable/robot_debris,
-/obj/item/stack/tile/iron/base,
-/turf/open/floor/mineral/titanium/yellow/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"M" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"O" = (
-/obj/structure/mecha_wreckage/odysseus,
-/turf/open/floor/mineral/titanium/yellow/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"P" = (
-/obj/item/stack/sheet/iron,
-/turf/template_noop,
-/area/ruin/space/has_grav/powered/mechtransport)
-"Q" = (
-/obj/structure/mecha_wreckage/gygax,
-/turf/open/floor/mineral/titanium/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"S" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/powered/mechtransport)
-"T" = (
-/turf/template_noop,
-/area/ruin/space/has_grav/powered/mechtransport)
-"V" = (
-/obj/item/stack/rods,
-/turf/template_noop,
-/area/ruin/space/has_grav/powered/mechtransport)
-"X" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/template_noop,
+"YQ" = (
+/turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/powered/mechtransport)
 
 (1,1,1) = {"
-a
-a
-a
-b
-d
-d
-d
-d
-G
-I
-M
-P
-T
-T
-T
+is
+is
+Ch
+Il
+Il
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+is
+wJ
+is
+is
 "}
 (2,1,1) = {"
-b
-d
-d
-d
-r
-v
-B
-E
-H
-S
-H
-I
-M
-V
-T
+is
+is
+Il
+iT
+kt
+HB
+YQ
+WC
+XO
+Bl
+XO
+Kv
+XO
+Bl
+WX
+wJ
+dq
+is
+is
+is
 "}
 (3,1,1) = {"
-c
-f
-k
-p
-s
-w
-w
-F
-w
-H
-M
-I
-I
-T
-T
+hR
+PG
+ce
+xJ
+lB
+yr
+yr
+yT
+gK
+DD
+NG
+DD
+gK
+DD
+Mn
+dq
+wJ
+wJ
+is
+is
 "}
 (4,1,1) = {"
-c
-g
-l
-d
-t
-w
-C
-G
-F
-w
-G
-H
-P
-T
-T
+is
+is
+Il
+mU
+Xe
+Qc
+YQ
+yT
+Ga
+ah
+vJ
+ah
+Te
+jZ
+GT
+KR
+is
+is
+is
+is
 "}
 (5,1,1) = {"
-c
-h
-m
-d
-s
-x
-w
-w
-y
-K
-O
-s
-S
-I
-T
+is
+is
+Ch
+YQ
+YQ
+YQ
+YQ
+sv
+OJ
+Gy
+DM
+CT
+OJ
+ko
+lP
+lc
+is
+is
+is
+is
 "}
 (6,1,1) = {"
-c
-i
-n
-d
-t
-y
-z
-w
-H
-L
-O
-H
-H
-T
-T
+is
+is
+is
+YQ
+uN
+Lk
+rD
+WX
+Oh
+DD
+Oh
+DD
+Oh
+hq
+hq
+is
+is
+PG
+is
+is
 "}
 (7,1,1) = {"
-c
-j
-J
-d
-t
-z
-w
-w
-y
-w
-w
-Q
-d
-b
-X
+is
+is
+is
+YQ
+YQ
+Ry
+YQ
+Lk
+XO
+DD
+XO
+DD
+XO
+nf
+kY
+wJ
+is
+is
+is
+PG
 "}
 (8,1,1) = {"
-b
-d
-d
-d
-u
-A
-y
-w
-w
-B
-y
-s
-d
-d
-X
+is
+is
+is
+is
+YQ
+YQ
+YQ
+dB
+uF
+DD
+qH
+Ov
+Cy
+DD
+jI
+if
+lc
+is
+is
+is
 "}
 (9,1,1) = {"
-a
-a
-a
-b
-d
-d
-D
-D
-D
-D
-D
-d
-b
-b
-X
+is
+is
+is
+is
+is
+YQ
+YQ
+dW
+Xs
+WN
+kl
+Xs
+Xs
+wJ
+is
+is
+is
+is
+is
+is
+"}
+(10,1,1) = {"
+is
+is
+is
+is
+is
+is
+Ch
+YQ
+XL
+XL
+XL
+XL
+sY
+is
+is
+is
+is
+is
+is
+is
 "}

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -68,7 +68,6 @@
 	floor_tile = /obj/item/stack/tile/catwalk_tile/iron
 	catwalk_type = "iron"
 
-
 /turf/open/floor/catwalk_floor/iron_white
 	name = "white plated catwalk floor"
 	icon_state = "whiteiron_above"
@@ -98,3 +97,22 @@
 	icon_state = "smoothiron_above"
 	floor_tile = /obj/item/stack/tile/catwalk_tile/iron_smooth
 	catwalk_type = "smoothiron"
+
+//Airless variants of the above
+/turf/open/floor/catwalk_floor/iron/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
+/turf/open/floor/catwalk_floor/iron_white/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
+/turf/open/floor/catwalk_floor/iron_dark/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
+/turf/open/floor/catwalk_floor/flat_white/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
+/turf/open/floor/catwalk_floor/titanium/Airless
+	initial_gas_mix = AIRLESS_ATMOS
+
+/turf/open/floor/catwalk_floor/iron_smooth/airless
+	initial_gas_mix = AIRLESS_ATMOS

--- a/code/game/turfs/open/floor/iron_floor.dm
+++ b/code/game/turfs/open/floor/iron_floor.dm
@@ -290,6 +290,9 @@
 	base_icon_state = "recharge_floor"
 	floor_tile = /obj/item/stack/tile/iron/recharge_floor
 
+/turf/open/floor/iron/recharge_floor/Airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/recharge_floor/asteroid
 	icon_state = "recharge_floor_asteroid"
 	base_icon_state = "recharge_floor_asteroid"
@@ -299,25 +302,40 @@
 	base_icon_state = "smooth"
 	floor_tile = /obj/item/stack/tile/iron/smooth
 
+/turf/open/floor/iron/smooth/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/smooth_edge
 	icon_state = "smooth_edge"
 	base_icon_state = "smooth_edge"
 	floor_tile = /obj/item/stack/tile/iron/smooth_edge
+
+/turf/open/floor/iron/smooth_edge/airless
+	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/iron/smooth_half
 	icon_state = "smooth_half"
 	base_icon_state = "smooth_half"
 	floor_tile = /obj/item/stack/tile/iron/smooth_half
 
+/turf/open/floor/iron/smooth_half/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/smooth_corner
 	icon_state = "smooth_corner"
 	base_icon_state = "smooth_corner"
 	floor_tile = /obj/item/stack/tile/iron/smooth_corner
 
+/turf/open/floor/iron/smooth_corner/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/smooth_large
 	icon_state = "smooth_large"
 	base_icon_state = "smooth_large"
 	floor_tile = /obj/item/stack/tile/iron/smooth_large
+
+/turf/open/floor/iron/smooth_large/airless
+	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/iron/terracotta
 	icon_state = "terracotta"
@@ -425,21 +443,36 @@
 	base_icon_state = "stairs"
 	tiled_dirt = FALSE
 
+/turf/open/floor/iron/stairs/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/stairs/left
 	icon_state = "stairs-l"
 	base_icon_state = "stairs-l"
+
+/turf/open/floor/iron/stairs/left/airless
+	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/iron/stairs/medium
 	icon_state = "stairs-m"
 	base_icon_state = "stairs-m"
 
+/turf/open/floor/iron/stairs/medium/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/stairs/right
 	icon_state = "stairs-r"
 	base_icon_state = "stairs-r"
 
+/turf/open/floor/iron/stairs/right/airless
+	initial_gas_mix = AIRLESS_ATMOS
+
 /turf/open/floor/iron/stairs/old
 	icon_state = "stairs-old"
 	base_icon_state = "stairs-old"
+
+/turf/open/floor/iron/stairs/old/airless
+	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/floor/iron/bluespace
 	icon_state = "bluespace"


### PR DESCRIPTION
## About The Pull Request

- Ports: https://github.com/tgstation/tgstation/pull/75121

All this really does is change up the old Mech transport ruin to look better and newer. Some airless variants of floors and catwalks have also been added to the code to make this possible.

## How Does This Help ***Gameplay***?
More ruins for pathfinders to explore.

## How Does This Help ***Roleplay***?
Minimal impact on RP.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/e9f72255-f244-47ac-a3ab-0629f3a0a155)

</details>

## Changelog
:cl:
qol: Mech transport ruin has better and more modern design.
/:cl: