### PR TITLE
Fix Job Preferences

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -232,7 +232,7 @@ SUBSYSTEM_DEF(job)
 			JobDebug("FOC player client no longer exists, Player: [player]")
 			continue
 		// Initial screening check. Does the player even have the job enabled, if they do - Is it at the correct priority level?
-		var/player_job_level = player.client?.prefs.job_preferences[job.title]
+		var/player_job_level = player.client?.prefs.job_preferences["[job.faction]_[job.title]"]
 		if(isnull(player_job_level))
 			JobDebug("FOC player job not enabled, Player: [player]")
 			continue
@@ -446,7 +446,7 @@ SUBSYSTEM_DEF(job)
 					continue
 
 				// Filter any job that doesn't fit the current level.
-				var/player_job_level = player.client?.prefs.job_preferences[job.title]
+				var/player_job_level = player.client?.prefs.job_preferences["[job.faction]_[job.title]"]
 				if(isnull(player_job_level))
 					JobDebug("FOC player job not enabled, Player: [player]")
 					continue
@@ -630,7 +630,7 @@ SUBSYSTEM_DEF(job)
 			if(job.required_playtime_remaining(player.client))
 				young++
 				continue
-			switch(player.client.prefs.job_preferences[job.title])
+			switch(player.client.prefs.job_preferences["[job.faction]_[job.title]"])
 				if(JP_HIGH)
 					high++
 				if(JP_MEDIUM)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//Quirk list
 	var/list/all_quirks = list()
 
-	//Job preferences 2.0 - indexed by job title , no key or value implies never
+	//Job preferences 2.0 - indexed by job faction + title, no key or value implies never. E.g: "artea_Chief Engineer"
 	var/list/job_preferences = list()
 
 	/// The current window, PREFERENCE_TAB_* in [`code/__DEFINES/preferences.dm`]
@@ -517,7 +517,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 				else
 					job_preferences[other_job] = JP_MEDIUM
 
-	job_preferences[job.title] = level
+	job_preferences["[job.faction]_[job.title]"] = level
 
 	return TRUE
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -507,7 +507,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 
 	if (level == JP_HIGH)
 		var/datum/job/overflow_role = SSjob.overflow_role
-		var/overflow_role_title = initial(overflow_role.title)
+		var/overflow_role_title = "[initial(overflow_role.faction)]_[initial(overflow_role.title)]"
 
 		for(var/other_job in job_preferences)
 			if(job_preferences[other_job] == JP_HIGH)

--- a/code/modules/client/preferences/middleware/jobs.dm
+++ b/code/modules/client/preferences/middleware/jobs.dm
@@ -15,7 +15,7 @@
 	if (isnull(job))
 		return FALSE
 
-	if (job.faction != FACTION_STATION)
+	if (job.faction != SSmapping.config.job_faction)
 		return FALSE
 
 	if (!preferences.set_job_preference_level(job, level))
@@ -52,6 +52,7 @@
 		jobs[job.title] = list(
 			"description" = job.description,
 			"department" = department_name,
+			"faction" = job.faction,
 		)
 
 	data["departments"] = departments

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
@@ -178,7 +178,7 @@ const JobRow = (
   const { className, job, name } = props;
 
   const isOverflow = data.overflow_role === name;
-  const priority = data.job_preferences[name];
+  const priority = data.job_preferences[job.faction + '_' + name];
 
   const createSetPriority = createCreateSetPriorityFromName(context, name);
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
@@ -355,7 +355,7 @@ export const JobsPage = () => {
     <>
       <JoblessRoleDropdown />
 
-      <Stack vertical fill>
+      <Stack vertical fill mt="4rem">
         <Gap amount={22} />
 
         <Stack.Item>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -74,6 +74,7 @@ export type Department = {
 export type Job = {
   description: string;
   department: string;
+  faction: string;
 };
 
 export type Quirk = {


### PR DESCRIPTION
## About The Pull Request

TL;DR, old job code made assumptions on job faction. That has been changed to validate from map config now.

Also, job prefs are now per-faction, cause that was an easy change to do.

Fixes #397

## How Does This Help ***Gameplay***?

You can actually roundstart as your job now.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/2055d06f-2d44-43ea-af3b-9bbb057adb0f)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/69e49bb2-0cba-4fa7-84f6-bfc8a229c6f0)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Job preferences can once again be set.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
