### PR TITLE
Fix Synth Screens Staying Between Species Change

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthetic.dm
@@ -84,6 +84,13 @@
 	if(isdummy(transformer)) // This is to make the dummy work properly with the synth parts. Cursed code.
 		set_limb_icons(transformer)
 
+/datum/species/synthetic/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
+	var/obj/item/organ/external/screen/screen = C.getorganslot(MUTANT_SYNTH_SCREEN) // This is such a hackjob fix, but whatever.
+	if(screen)
+		screen.Remove(C)
+		qdel(screen)
+	. = ..()
+
 /datum/species/synthetic/replace_body(mob/living/carbon/target, datum/species/new_species)
 	. = ..()
 	set_limb_icons(target)


### PR DESCRIPTION
## About The Pull Request

This could be considered a regression, but frankly, I don't have the manpower to move away from species datums, plus, they're kinda convenient for shitcoders like me.

Fixes #394 

## How Does This Help ***Gameplay***?

You can now switch between synth and other species in character prefs without having your preview fucked up.

## Proof of Testing

See test merge, I don't have time.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed synth screens persisting between species in the character creator.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
