### PR TITLE
Fix SSday_night Showing Init Warnings

### DIFF
--- a/code/controllers/subsystem/day_night.dm
+++ b/code/controllers/subsystem/day_night.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(day_night)
 	name = "Day and Night Cycle"
-	flags = SS_BACKGROUND
+	flags = SS_BACKGROUND | SS_NO_INIT
 	wait = 1.5 MINUTES
 	runlevels = RUNLEVEL_GAME
 	var/list/day_night_controllers = list()


### PR DESCRIPTION
## About The Pull Request

Tin. 

## Proof of Testing

Warning in console is gone, see actions logs.

## Changelog

No CL, non-player facing.
