### PR TITLE
[PORT] Swipes Cyborg Chargers Working on Synths From Bubber

### DIFF
--- a/code/modules/surgery/organs/stomach/stomach_synth.dm
+++ b/code/modules/surgery/organs/stomach/stomach_synth.dm
@@ -47,7 +47,8 @@
 	SIGNAL_HANDLER
 
 	// This is so it isn't completely instant
-	amount /= 200
+	// This is called ~once every second, so it'd take ~40s to fully charge from stock t1 parts (amount = 200) from empty.
+	amount /= 15
 	if(owner.nutrition < NUTRITION_LEVEL_WELL_FED)
 		owner.nutrition += amount
 		if(owner.nutrition > NUTRITION_LEVEL_FULL)

--- a/code/modules/surgery/organs/stomach/stomach_synth.dm
+++ b/code/modules/surgery/organs/stomach/stomach_synth.dm
@@ -27,5 +27,31 @@
 			owner.nutrition = max(0, owner.nutrition - SYNTH_STOMACH_LIGHT_EMP_CHARGE_LOSS)
 			to_chat(owner, span_warning("Alert: Minor battery discharge!"))
 
+/obj/item/organ/internal/stomach/synth/Insert(mob/living/carbon/receiver, special, drop_if_replaced)
+	. = ..()
+	add_synth_signals(receiver)
+
+/obj/item/organ/internal/stomach/synth/Remove(mob/living/carbon/stomach_owner, special)
+	. = ..()
+	remove_synth_signals(stomach_owner)
+
+/obj/item/organ/internal/stomach/synth/proc/add_synth_signals(mob/living/carbon/stomach_owner)
+	SIGNAL_HANDLER
+	RegisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(on_borg_charge))
+
+/obj/item/organ/internal/stomach/synth/proc/remove_synth_signals(mob/living/carbon/stomach_owner)
+	SIGNAL_HANDLER
+	UnregisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT)
+
+/obj/item/organ/internal/stomach/synth/proc/on_borg_charge(datum/source, amount)
+	SIGNAL_HANDLER
+
+	// This is so it isn't completely instant
+	amount /= 200
+	if(owner.nutrition < NUTRITION_LEVEL_WELL_FED)
+		owner.nutrition += amount
+		if(owner.nutrition > NUTRITION_LEVEL_FULL)
+			owner.nutrition = NUTRITION_LEVEL_ALMOST_FULL
+
 #undef SYNTH_STOMACH_LIGHT_EMP_CHARGE_LOSS
 #undef SYNTH_STOMACH_HEAVY_EMP_CHARGE_LOSS


### PR DESCRIPTION
## About The Pull Request

Stolen from https://github.com/Bubberstation/Bubberstation/pull/716

I swear I did this already, but apparently not. Anyways, why reinvent the wheel when I've been made aware of already perfectly functional code?

## How Does This Help ***Gameplay***?

Synths now actually can charge from the places the food alert says they can.

## How Does This Help ***Roleplay***?

Oh look, synths now actually charge from things they should be able to!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/4645c3c2-1458-40e0-a315-b7f6f12f3048)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/6e2e5cb2-00b6-4944-bf34-5482910cee75)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Majkl-J (original), RimiNosha (port)
add: Synths can now charge at cyborg chargers!
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
