### PR TITLE
Increases GC Wait on CI Cause Qdel Isn't so Q on 515

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -139,7 +139,8 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	SSticker.delay_end = TRUE
 
 	// Drastically lower the amount of time it takes to GC, since we don't have clients that can hold it up.
-	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = 10 SECONDS
+	// Except lighting and gravgens have a tendency to hold GC for a moment. - Rimi
+	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = 30 SECONDS
 	//Prevent the garbage subsystem from harddeling anything, if only to save time
 	SSgarbage.collection_timeout[GC_QUEUE_HARDDELETE] = 10000 HOURS
 	//Clear it, just in case


### PR DESCRIPTION
## About The Pull Request

Stolen https://github.com/DaedalusDock/daedalusdock/pull/730

Misleading title, somewhat. 

On 515, the queue can get held up by lighting<sup>?</sup>. No idea why, and frankly, I don't care too much, and this seemed to fix a similar issue on DD.
