### PR TITLE
Nosha > Ryoshi

### DIFF
--- a/code/__DEFINES/manufacturers.dm
+++ b/code/__DEFINES/manufacturers.dm
@@ -1,7 +1,7 @@
 // This file is to contain manufacturer defines.
 // Manufacturer names should be in a similar format to existing ones, or they won't make sense.
 
-#define MANUFACTURER_NOSHA_INDUSTRIES "<b><span class=\"purple\">Nosha Industries</span></b> etched into"
+#define MANUFACTURER_RYOSHI_INDUSTRIES "<b><span class=\"purple\">Ryoshi Industries</span></b> etched into"
 
 #define MANUFACTURER_ARTEA_LOGISTICS "<b><span class=\"engradio\">Artea Logistics</span></b> stamped onto"
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -54,7 +54,7 @@
 		/obj/item/stock_parts/matter_bin = 3,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stack/sheet/glass = 1)
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 /obj/item/circuitboard/machine/grounding_rod
 	name = "Grounding Rod"
@@ -64,7 +64,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/telecomms
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 /obj/item/circuitboard/machine/telecomms/broadcaster
 	name = "Subspace Broadcaster"
@@ -374,7 +374,7 @@
 		/obj/item/stock_parts/matter_bin = 1,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/reagent_containers/cup/beaker = 2)
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 /obj/item/circuitboard/machine/circuit_imprinter/offstation
 	name = "Ancient Circuit Imprinter"
@@ -426,7 +426,7 @@
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/manipulator = 2,
 		/obj/item/reagent_containers/cup/beaker = 2)
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 /obj/item/circuitboard/machine/protolathe/offstation
 	name = "Ancient Protolathe"

--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -11,7 +11,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	worn_icon_state = "electronic"
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 	/// Spam alert prevention
 	var/alert_cooldown

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -2,7 +2,7 @@
 	name = "technology fabricator"
 	desc = "Makes researched and prototype items with materials and energy."
 	layer = BELOW_OBJ_LAYER
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 	/// The efficiency coefficient. Material costs and print times are multiplied by this number;
 	/// better parts result in a higher efficiency (and lower value).

--- a/code/modules/surgery/organs/brain_synth.dm
+++ b/code/modules/surgery/organs/brain_synth.dm
@@ -14,7 +14,7 @@
 	icon_state = "posibrain-ipc"
 	/// The last time (in ticks) a message about brain damage was sent. Don't touch.
 	var/last_message_time = 0
-	manufacturer = MANUFACTURER_NOSHA_INDUSTRIES
+	manufacturer = MANUFACTURER_RYOSHI_INDUSTRIES
 
 /obj/item/organ/internal/brain/synth/Insert(mob/living/carbon/user, special = FALSE, drop_if_replaced = TRUE, no_id_transfer = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Nosha isn't a name I'd like to attach to server lore, due to the fact that Nosha kinda predates the lore by many years, and has a distinctly different meaning to me compared to the lore folk.

I'd also rather not have folk be able to point at me and say I'm playing favourites in terms of factions due to the name sharing between my (debatably) OOC name and the in-game faction.

## How Does This Help ***Roleplay***?

A much, much more fitting name for the ethos, structure, and abilities of the faction. This change is being made to reflect what's in lore docs.

:cl:
spellcheck: Nosha Industries has been renamed to Ryoshi Industries
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
