### PR TITLE
Mini Soundening (overmap edition)

### DIFF
--- a/code/modules/overmap/overmap_lock.dm
+++ b/code/modules/overmap/overmap_lock.dm
@@ -45,3 +45,4 @@
 		return
 	is_calibrated = TRUE
 	effect.icon_state = "locked"
+	playsound(usr, 'sound/machines/triple_beep.ogg', 75, TRUE)

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -349,6 +349,7 @@
 		DisplayHelmPad(usr)
 
 /datum/overmap_object/shuttle/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	playsound(usr, SFX_PDA, 50, TRUE, ignore_walls = FALSE)
 	..()
 	. = TRUE
 
@@ -464,6 +465,7 @@
 			if(!lock)
 				return
 			target_command = TARGET_BEAM_ON_BOARD
+			playsound(usr, 'sound/machines/wewewew.ogg', 70, TRUE)
 		if("target")
 			if(!(shuttle_capability & SHUTTLE_CAN_USE_SENSORS))
 				return


### PR DESCRIPTION
## About The Pull Request
Mini soundening for overmap shuttle UI. Purely doing this because while flying the ship during the playtest it gets boring to not hear sounds other than ambience.

- Successfully locking onto targets now beeps at you.
- Pressing buttons in the UI will also beep at you.
- Beaming stuff on board has a whooshing sound.

## How Does This Help ***Gameplay***?
Makes shuttles a little nicer to fly because your UI actions will actually come with feedback now!

## How Does This Help ***Roleplay***?
Immersion™️ ? 

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

# **SOUND ON YOU FOOL!!!!**

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/e2ae47da-2f00-4802-a64c-09dfaee00865

</details>

## Changelog

:cl:
qol: Shuttle control consoles now have sounds added to UI interactions, no more silence when you're flying ships and shuttles, you get boops and beeps!
/:cl: