### PR TITLE
Allow Numbers in Any Name

### DIFF
--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -11,9 +11,6 @@
 	/// These will be grouped together on the preferences menu
 	var/group
 
-	/// Whether or not to allow numbers in the person's name
-	var/allow_numbers = FALSE
-
 	/// If the highest priority job matches this, will prioritize this name in the UI
 	var/relevant_job
 
@@ -22,15 +19,15 @@
 	return
 
 /datum/preference/name/deserialize(input, datum/preferences/preferences)
-	return reject_bad_name("[input]", allow_numbers)
+	return reject_bad_name("[input]", allow_numbers = TRUE)
 
 /datum/preference/name/serialize(input)
 	// `is_valid` should always be run before `serialize`, so it should not
 	// be possible for this to return `null`.
-	return reject_bad_name(input, allow_numbers)
+	return reject_bad_name(input, allow_numbers = TRUE)
 
 /datum/preference/name/is_valid(value)
-	return istext(value) && !isnull(reject_bad_name(value, allow_numbers))
+	return istext(value) && !isnull(reject_bad_name(value, allow_numbers = TRUE))
 
 /// A character's real name
 /datum/preference/name/real_name
@@ -63,7 +60,7 @@
 		else if(first_space == length(input))
 			input += "[pick(GLOB.last_names)]"
 
-	return reject_bad_name(input, allow_numbers)
+	return reject_bad_name(input, allow_numbers = TRUE)
 
 /// The name for a backup human, when nonhumans are made into head of staff
 /datum/preference/name/backup_human
@@ -98,10 +95,7 @@
 
 /datum/preference/name/cyborg
 	savefile_key = "cyborg_name"
-
-	allow_numbers = TRUE
 	can_randomize = FALSE
-
 	explanation = "Cyborg name"
 	group = "silicons"
 	relevant_job = /datum/job/cyborg
@@ -111,8 +105,6 @@
 
 /datum/preference/name/ai
 	savefile_key = "ai_name"
-
-	allow_numbers = TRUE
 	explanation = "AI name"
 	group = "silicons"
 	relevant_job = /datum/job/ai
@@ -122,9 +114,6 @@
 
 /datum/preference/name/religion
 	savefile_key = "religion_name"
-
-	allow_numbers = TRUE
-
 	explanation = "Religion name"
 	group = "religion"
 
@@ -133,10 +122,7 @@
 
 /datum/preference/name/deity
 	savefile_key = "deity_name"
-
-	allow_numbers = TRUE
 	can_randomize = FALSE
-
 	explanation = "Deity name"
 	group = "religion"
 
@@ -145,10 +131,7 @@
 
 /datum/preference/name/bible
 	savefile_key = "bible_name"
-
-	allow_numbers = TRUE
 	can_randomize = FALSE
-
 	explanation = "Bible name"
 	group = "religion"
 


### PR DESCRIPTION
## About The Pull Request

Breaks synth naming. V bad.

## How Does This Help ***Roleplay***?

You can be called what you should be called in-game.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/f18f890b-6a5b-47d3-895f-a67daf010f87)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Names can now have numbers, as they should've had from the beginning.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
