### PR TITLE
Removes Runed metal from Overmap loot table

### DIFF
--- a/code/game/objects/effects/spawners/random/materials.dm
+++ b/code/game/objects/effects/spawners/random/materials.dm
@@ -5,8 +5,6 @@
 	name = "material spawner"
 	loot = list(
 		/obj/item/stack/sheet/plastic/fifty = 5,
-		/obj/item/stack/sheet/runed_metal/ten = 20,
-		/obj/item/stack/sheet/runed_metal/fifty = 5,
 		/obj/item/stack/sheet/mineral/diamond{amount = 15} = 15,
 		/obj/item/stack/sheet/mineral/uranium{amount = 15} = 15,
 		/obj/item/stack/sheet/mineral/plasma{amount = 15} = 15,


### PR DESCRIPTION
## About The Pull Request

Removes Runed metal from Overmap loot table.
Across the several playtests we have had now Runed metal has been piling up in cargo throughout the round and it cant be usedso I'm removing it for two reasons:
- We dont have cult active as antagonist.
- Runed metal cannot be used by crew.

## How Does This Help ***Gameplay***?
No more useless items from Overmap loot, yippee

## How Does This Help ***Roleplay***?
Immersion?

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Just trust me on this one, it works.

</details>

## Changelog
:cl:
del: Removed Runed metal from overmap loot.
/:cl: