### PR TITLE
Fixes Synth Bodyparts Staying Inside Prefs Previews

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthetic.dm
@@ -81,9 +81,6 @@
 		appendix.Remove(transformer)
 		qdel(appendix)
 
-	if(isdummy(transformer)) // This is to make the dummy work properly with the synth parts. Cursed code.
-		set_limb_icons(transformer)
-
 /datum/species/synthetic/replace_body(mob/living/carbon/target, datum/species/new_species)
 	. = ..()
 	set_limb_icons(target)

--- a/code/modules/mob/living/carbon/human/species_types/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthetic.dm
@@ -81,6 +81,9 @@
 		appendix.Remove(transformer)
 		qdel(appendix)
 
+	if(isdummy(transformer)) // This is to make the dummy work properly with the synth parts. Cursed code.
+		set_limb_icons(transformer)
+
 /datum/species/synthetic/replace_body(mob/living/carbon/target, datum/species/new_species)
 	. = ..()
 	set_limb_icons(target)

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -23,7 +23,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
-	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
 	brute_reduction = 5
@@ -55,7 +54,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
-	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
 	brute_reduction = 5
@@ -88,7 +86,7 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
-	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
+
 	dmg_overlay_type = "robotic"
 
 	brute_reduction = 5
@@ -130,7 +128,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
-	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
 	brute_reduction = 5
@@ -171,7 +168,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
-	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
 	brute_reduction = 5
@@ -298,7 +294,6 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
-	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
 	brute_reduction = 5


### PR DESCRIPTION
## About The Pull Request

Hahahahahaha, I CAN'T BELIEVE IT WAS A ONE LINE FIX

Downside is that prosthetic limb gradually eats all limbs. Need to remind it to not fuck with limbs after the first load.

## How Does This Help ***Gameplay***?

Less closing and reopening of prefs.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/5ef59911-13a4-46a3-890f-897138d44e77)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/c5e80d0d-77f5-45ca-bd9b-0207f58f09e7)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Fixed synth limbs staying between species change in prefs.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
