### PR TITLE
Fix Matchmaking Panel Not Showing Anyone

### DIFF
--- a/code/datums/matchmaking_panel.dm
+++ b/code/datums/matchmaking_panel.dm
@@ -12,7 +12,7 @@ GLOBAL_DATUM_INIT(matchmaking_panel, /datum/matchmaking_panel, new)
 /datum/matchmaking_panel/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "MatchmakingPanel")
+		ui = new(user, src, "MatchmakingPanel", "Matchmaking Panel")
 		ui.open()
 
 /datum/matchmaking_panel/ui_data(mob/user)
@@ -55,7 +55,7 @@ GLOBAL_DATUM_INIT(matchmaking_panel, /datum/matchmaking_panel, new)
 
 		if(ishuman(client.mob))
 			var/mob/living/carbon/human/human = client.mob
-			if(!find_record("name", human.real_name, GLOB.manifest.general))
+			if(!find_record(human.real_name, TRUE))
 				continue
 			name = human.real_name
 			species = human.dna.species.name


### PR DESCRIPTION
## About The Pull Request

When I did #216 I forgot to update the proc that ensures someone exists as an actual "human". Woops.

## How Does This Help ***Gameplay***?

Antags can once again see who they're able to mess with.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/9e6fa91a-00c6-4b67-9275-b7767af836ee)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/aa4af0bf-0a2f-4ba0-b652-abf93f69cbf4)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: The matchmaking panel now displays properly.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
