### PR TITLE
[Port] Examining things will now put a message in the chat.

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -110,7 +110,7 @@
 #define span_subtle(str) ("<span class='subtle'>" + str + "</span>")
 #define span_suicide(str) ("<span class='suicide'>" + str + "</span>")
 #define span_suppradio(str) ("<span class='suppradio'>" + str + "</span>")
-#define span_subtle(str) ("<spanb class='subtle'>" + str + "</span>")
+#define span_examine(str) ("<spanb class='examine'>" + str + "</span>")
 #define span_syndradio(str) ("<span class='syndradio'>" + str + "</span>")
 #define span_tape_recorder(str) ("<span class='tape_recorder'>" + str + "</span>")
 #define span_tinynotice(str) ("<span class='tinynotice'>" + str + "</span>")

--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -110,6 +110,7 @@
 #define span_subtle(str) ("<span class='subtle'>" + str + "</span>")
 #define span_suicide(str) ("<span class='suicide'>" + str + "</span>")
 #define span_suppradio(str) ("<span class='suppradio'>" + str + "</span>")
+#define span_subtle(str) ("<spanb class='subtle'>" + str + "</span>")
 #define span_syndradio(str) ("<span class='syndradio'>" + str + "</span>")
 #define span_tape_recorder(str) ("<span class='tape_recorder'>" + str + "</span>")
 #define span_tinynotice(str) ("<span class='tinynotice'>" + str + "</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -548,6 +548,16 @@
 			client.recent_examines[ref_to_atom] = world.time // set to when we last normal examine'd them
 			addtimer(CALLBACK(src, PROC_REF(clear_from_recent_examines), ref_to_atom), RECENT_EXAMINE_MAX_WINDOW)
 			handle_eye_contact(examinify)
+
+			if(!isobserver(usr) && !(usr == examinify))
+				var/list/can_see_target = viewers(usr)
+				for(var/mob/M as anything in viewers(4, usr))
+					if(!M.client)
+						continue
+					if(M in can_see_target)
+						to_chat(M, span_subtle("\The [usr] looks at \the [examinify]"))
+					else
+						to_chat(M, span_subtle("\The [usr] intently looks at something..."))
 	else
 		result = examinify.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -555,9 +555,9 @@
 					if(!M.client)
 						continue
 					if(M in can_see_target)
-						to_chat(M, span_subtle("\The [usr] looks at \the [examinify]"))
+						to_chat(M, span_examine("\The [usr] looks at \the [examinify]"))
 					else
-						to_chat(M, span_subtle("\The [usr] intently looks at something..."))
+						to_chat(M, span_examine("\The [usr] intently looks at something..."))
 	else
 		result = examinify.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1073,7 +1073,7 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.subtle {
+.exmaine {
   color: #4343ca;
   font-size: 75%;
   font-style: italic;

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1072,3 +1072,9 @@ $border-width-px: $border-width * 1px;
     background-color: darken(map.get($alert-stripe-colors, $color-name), 5);
   }
 }
+
+.subtle {
+  color: #4343ca;
+  font-size: 75%;
+  font-style: italic;
+}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -1073,7 +1073,7 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.exmaine {
+.examine {
   color: #4343ca;
   font-size: 75%;
   font-style: italic;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1105,3 +1105,9 @@ $border-width-px: $border-width * 1px;
     );
   }
 }
+
+.subtle {
+  color: #000099;
+  font-size: 75%;
+  font-style: italic;
+}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -1106,7 +1106,7 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.subtle {
+.examine {
   color: #000099;
   font-size: 75%;
   font-style: italic;


### PR DESCRIPTION
## About The Pull Request
Ports:
- https://github.com/DaedalusDock/daedalusdock/pull/27

This PR will now make it so that whenever someone examines something a small message will be put in the chat that they did that. (Yes this is visible to everyone, not just the user)
Pretty nice to have on a HRP server if you ask me.

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/26387adf-f904-4492-9fe8-c2eceecc088b)

## How Does This Help ***Gameplay***?
Minimal impact on gameplay aside from a small message being put in the chat when you examine someone.

## How Does This Help ***Roleplay***?
People will now know when they're being looked at and what others are looking at each time they examine something. Can lead to People not wanting to be looked at by others or other fun RP like that.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/949ff877-36ea-4b77-a866-889734f63160

</details>

## Changelog
:cl:
add: Examining things will now put a message into the chat for people nearby to see what you just looked at.
/:cl: