### PR TITLE
[PORT] Autoconnect Canister Ports, Make Bearcat Fuel Lines Actually Work

### DIFF
--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -1455,8 +1455,8 @@
 /area/space/nearstation)
 "id" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -1960,6 +1960,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"kY" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "lb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -2198,8 +2204,10 @@
 /area/station/cargo/warehouse)
 "me" = (
 /obj/effect/decal/cleanable/ash,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "SM Waste to Fuel Pump"
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -2550,10 +2558,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "nV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/auto_connect{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "nX" = (
@@ -4106,11 +4114,11 @@
 /turf/open/floor/iron/white,
 /area/station/pathfinders/pathfinders_armory)
 "wb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/auto_connect{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wc" = (
@@ -4470,10 +4478,7 @@
 "yw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 1;
-	name = "SM Waste to Fuel Pump"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "yy" = (
@@ -172990,7 +172995,7 @@ HS
 EA
 ew
 uj
-pm
+kY
 rr
 rK
 Kf

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -52,6 +52,15 @@
 		to_chat(user, span_warning("You cannot unwrench [src], detach [connected_device] first!"))
 		return FALSE
 
+/obj/machinery/atmospherics/components/unary/portables_connector/connect_roundstart/build_network()
+	. = ..()
+	var/obj/machinery/portable_atmospherics/canister = locate(/obj/machinery/portable_atmospherics) in loc
+	if(canister)
+		canister.connect(src)
+		return
+	// Crash so CI gets angry
+	CRASH("No connectable found on top of the portables connector at [x], [y], [z]! Fix this.")
+
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2
 	piping_layer = 2
 	icon_state = "connector_map-2"

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -17,11 +17,16 @@
 
 	///Reference to the connected device
 	var/obj/machinery/portable_atmospherics/connected_device
+	/// If TRUE, it will try to connect to a canister on roundstart.
+	var/connect_roundstart = FALSE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/New()
 	. = ..()
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = 0
+	if(!connect_roundstart)
+		return
+	addtimer(CALLBACK(src, PROC_REF(connect_to_canister)), 1 SECONDS)
 
 /obj/machinery/atmospherics/components/unary/portables_connector/Destroy()
 	if(connected_device)
@@ -52,8 +57,8 @@
 		to_chat(user, span_warning("You cannot unwrench [src], detach [connected_device] first!"))
 		return FALSE
 
-/obj/machinery/atmospherics/components/unary/portables_connector/connect_roundstart/build_network()
-	. = ..()
+/obj/machinery/atmospherics/components/unary/portables_connector/proc/connect_to_canister()
+	connect_roundstart = FALSE
 	var/obj/machinery/portable_atmospherics/canister = locate(/obj/machinery/portable_atmospherics) in loc
 	if(canister)
 		canister.connect(src)
@@ -61,21 +66,39 @@
 	// Crash so CI gets angry
 	CRASH("No connectable found on top of the portables connector at [x], [y], [z]! Fix this.")
 
+/obj/machinery/atmospherics/components/unary/portables_connector/auto_connect
+	connect_roundstart = TRUE
+
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2
 	piping_layer = 2
 	icon_state = "connector_map-2"
+
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2/auto_connect
+	connect_roundstart = TRUE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4
 	piping_layer = 4
 	icon_state = "connector_map-4"
 
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4/auto_connect
+	connect_roundstart = TRUE
+
 /obj/machinery/atmospherics/components/unary/portables_connector/visible
 	hide = FALSE
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/auto_connect
+	connect_roundstart = TRUE
 
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2
 	piping_layer = 2
 	icon_state = "connector_map-2"
 
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2/auto_connect
+	connect_roundstart = TRUE
+
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4
 	piping_layer = 4
 	icon_state = "connector_map-4"
+
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4/auto_connect
+	connect_roundstart = TRUE


### PR DESCRIPTION
## About The Pull Request

https://github.com/BeeStation/BeeStation-Hornet/pull/10413

Stolen before the PR was even merged. I've only stolen a footnote feature from it.

## How Does This Help ***Gameplay***?

tl;dr: Allows things like telecomms cold rooms and ship engines to not have to rely on someone wrenching the canister. Also could be used when admin spawning shuttles in the future.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/e1aa123b-2a04-4aca-a36e-4a118b8cf6cc)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Canister ports now have a roundstart connect variant.
fix: Bearcat's fuel lines no longer start with bad piping. Woops.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
