### PR TITLE
Synth Damage Balance Changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1849,7 +1849,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		// Very high pressure, show an alert and take damage
 		if(HAZARD_HIGH_PRESSURE to INFINITY)
 			if(!HAS_TRAIT(H, TRAIT_RESISTHIGHPRESSURE))
-				H.adjustBruteLoss(min(((adjusted_pressure / HAZARD_HIGH_PRESSURE) - 1) * PRESSURE_DAMAGE_COEFFICIENT, MAX_HIGH_PRESSURE_DAMAGE) * H.physiology.pressure_mod * delta_time, required_bodytype = BODYTYPE_ORGANIC)
+				H.adjustBruteLoss(min(((adjusted_pressure / HAZARD_HIGH_PRESSURE) - 1) * PRESSURE_DAMAGE_COEFFICIENT, MAX_HIGH_PRESSURE_DAMAGE) * H.physiology.pressure_mod * delta_time)
 				H.throw_alert(ALERT_PRESSURE, /atom/movable/screen/alert/highpressure, 2)
 			else
 				H.clear_alert(ALERT_PRESSURE)
@@ -1876,7 +1876,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			if(HAS_TRAIT(H, TRAIT_RESISTLOWPRESSURE))
 				H.clear_alert(ALERT_PRESSURE)
 			else
-				H.adjustBruteLoss(LOW_PRESSURE_DAMAGE * H.physiology.pressure_mod * delta_time, required_bodytype = BODYTYPE_ORGANIC)
+				H.adjustBruteLoss(LOW_PRESSURE_DAMAGE * H.physiology.pressure_mod * delta_time)
 				H.throw_alert(ALERT_PRESSURE, /atom/movable/screen/alert/lowpressure, 2)
 
 

--- a/code/modules/mob/living/carbon/human/species_types/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthetic.dm
@@ -62,8 +62,8 @@
 	digitigrade_customization = DIGITIGRADE_OPTIONAL
 	burnmod = 1.3 // Every 0.1 is 10% above the base.
 	brutemod = 1.3
-	coldmod = 1.2
-	heatmod = 2 // TWO TIMES DAMAGE FROM BEING TOO HOT?! WHAT?! No wonder lava is literal instant death for us.
+	coldmod = 1.1
+	heatmod = 1.5
 	siemens_coeff = 1.4 // Not more because some shocks will outright crit you, which is very unfun
 
 /datum/species/synthetic/spec_life(mob/living/carbon/human/human)

--- a/code/modules/mob/living/carbon/human/species_types/synthetic.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthetic.dm
@@ -62,7 +62,7 @@
 	digitigrade_customization = DIGITIGRADE_OPTIONAL
 	burnmod = 1.3 // Every 0.1 is 10% above the base.
 	brutemod = 1.3
-	coldmod = 1.1
+	coldmod = 1.2
 	heatmod = 1.5
 	siemens_coeff = 1.4 // Not more because some shocks will outright crit you, which is very unfun
 


### PR DESCRIPTION
## About The Pull Request

This PR does the following:
- Makes synths (and by extension, robotic bodyparts) no longer immune to pressure damage.
- Makes synths take 150% heat damage (down from 200%).

## How Does This Help ***Gameplay***?

Synths are much better to play as. Having being on fire or even slightly touching lava be a near instant death for you is not fun.

Also yeets TG's OP pressure damage ignorance from robotic limbs, cause we're likely going to be handing those out like candy in the future.

## How Does This Help ***Roleplay***?

Synths can no longer ignore what is normally a universal threat to the station.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Trust me bro, it's 1am.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Robotic limbs (including synths) now take pressure damage.
balance: Synths now take 150% heat damage (down from 200%).
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
