### PR TITLE
Fix SM Fuel Line (Again) and Adjust External Vents

### DIFF
--- a/_maps/map_files/Bearcat/Bearcat.dmm
+++ b/_maps/map_files/Bearcat/Bearcat.dmm
@@ -2168,11 +2168,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"lW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/obj/structure/lattice,
-/turf/open/space/openspace,
-/area/space/nearstation)
 "lZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2406,10 +2401,6 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/ai_monitored/command/storage/eva)
-"ni" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "nj" = (
 /obj/effect/turf_decal/bot_orange,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3202,7 +3193,9 @@
 /turf/open/openspace,
 /area/station/cargo/sorting)
 "rr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "SM Waste to Fuel Pump"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rs" = (
@@ -3513,11 +3506,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"tm" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/space/openspace,
-/area/space/nearstation)
 "tn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4270,11 +4258,6 @@
 	luminosity = 2
 	},
 /area/station/engineering/supermatter)
-"xw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xx" = (
 /obj/effect/turf_decal/stripes/orange/corner{
 	dir = 8
@@ -7974,10 +7957,6 @@
 /obj/machinery/holomap/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"RJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "RK" = (
 /obj/item/stack/ore/glass{
 	amount = 5
@@ -9133,13 +9112,6 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
-"Yg" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "SM Waste to Fuel Pump"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "Yh" = (
 /obj/effect/turf_decal/bot_orange,
 /turf/open/floor/iron/cafeteria,
@@ -9269,7 +9241,6 @@
 "YV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "YW" = (
@@ -169992,10 +169963,10 @@ HT
 HT
 HT
 HT
-ni
-RJ
-xw
-xw
+HT
+HT
+uN
+aZ
 NK
 NK
 NK
@@ -171289,7 +171260,7 @@ Gk
 Gk
 Gk
 sq
-aZ
+AC
 NK
 NK
 NK
@@ -171546,7 +171517,7 @@ Gk
 iq
 gV
 sq
-tm
+AC
 NK
 NK
 NK
@@ -171803,10 +171774,10 @@ TA
 ST
 Ev
 sq
-xw
-tm
-lW
-lW
+uN
+AC
+AC
+aZ
 NK
 AC
 NK
@@ -172837,7 +172808,7 @@ EA
 ew
 uj
 kY
-rr
+JM
 rK
 Kf
 NK
@@ -173094,7 +173065,7 @@ ce
 ew
 jL
 ht
-Yg
+JM
 rK
 Kf
 NK
@@ -173351,7 +173322,7 @@ eI
 dX
 uj
 id
-rr
+JM
 DZ
 DY
 NK


### PR DESCRIPTION
## About The Pull Request

- Moves the two vents for the SM and atmos back next to their windows. The bug that necessitated their positions were fixed, so.
- SM waste to fuel line is now properly separated via pump.

## How Does This Help ***Gameplay***?

Engi QoL.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

See MDB.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Moved exterior vents to easier to see locations on Bearcat.
fix: Fixed SM waste to ship fuel line on Bearcat (again).
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
