### PR TITLE
SSair VV QoL, Fix Startup Warning

### DIFF
--- a/code/controllers/subsystem/zas.dm
+++ b/code/controllers/subsystem/zas.dm
@@ -124,6 +124,20 @@ SUBSYSTEM_DEF(zas)
 	///The last process, as a string, before the previous run ended.
 	var/last_process
 
+/datum/controller/subsystem/zas/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION("", "---")
+	VV_DROPDOWN_OPTION("zas_reboot", "Reboot ZAS")
+
+/datum/controller/vv_do_topic(list/href_list)
+	. = ..()
+	if(!.) // This means a safety check failed or this was cancelled
+		return
+	if(href_list["zas_reboot"])
+		log_admin("[usr] rebooted SSair.")
+		message_admins("[usr] rebooted SSair.")
+		Reboot()
+
 ///Stops processing while all ZAS-controlled airs and fires are nulled and the subsystem is reinitialized.
 /datum/controller/subsystem/zas/proc/Reboot()
 	// Stop processing while we rebuild.
@@ -200,7 +214,7 @@ SUBSYSTEM_DEF(zas)
 
 		log_zas("ZAS: Air settling completed in [(REALTIMEOFDAY - starttime)/10] seconds!")
 
-	..(timeofday)
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/zas/fire(resumed = FALSE, no_mc_tick)
 	var/timer = TICK_USAGE_REAL

--- a/code/controllers/subsystem/zas.dm
+++ b/code/controllers/subsystem/zas.dm
@@ -129,7 +129,7 @@ SUBSYSTEM_DEF(zas)
 	VV_DROPDOWN_OPTION("", "---")
 	VV_DROPDOWN_OPTION("zas_reboot", "Reboot ZAS")
 
-/datum/controller/vv_do_topic(list/href_list)
+/datum/controller/subsystem/zas/vv_do_topic(list/href_list)
 	. = ..()
 	if(!.) // This means a safety check failed or this was cancelled
 		return


### PR DESCRIPTION
## About The Pull Request

I forgor to update the subsystem init to return the funny success message.

Also makes it so VVing SSair gives you a direct option to reboot (this means reset all gasses to their initial values).

## How Does This Help ***Gameplay***?

Makes it easier for admins to unfuck ZAS should something unfathomable happen like engis fucking the reactor airmix.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

I would, but I'm currently knee deep in RBMK code.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
admin: SSair can now be rebooted easily via the VV dropdown.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
