### PR TITLE
Fix Job Previews Not Loading

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(job)
 	var/list/datum/job/joinable_occupations = list()
 	/// Dictionary of all jobs, keys are titles.
 	var/list/name_occupations = list()
+	/// Dictionary of all jobs, keys are titles with factions (faction_title).
+	var/list/name_faction_occupations = list()
 	/// Dictionary of all jobs, keys are types.
 	var/list/datum/job/type_occupations = list()
 
@@ -141,6 +143,7 @@ SUBSYSTEM_DEF(job)
 			GLOB.nonhuman_positions[job.title] = TRUE
 
 		name_occupations[job.title] = job
+		name_faction_occupations["[job.faction]_[job.title]"] = job
 		type_occupations[job_type] = job
 		if(job.job_flags & JOB_NEW_PLAYER_JOINABLE && job.faction == faction)
 			new_joinable_occupations += job

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -74,12 +74,12 @@
 
 /// Returns what job is marked as highest
 /datum/preferences/proc/get_highest_priority_job()
-	var/datum/job/preview_job
+	var/datum/job/preview_job = /datum/job/assistant
 	var/highest_pref = 0
 
 	for(var/job in job_preferences)
-		if(job_preferences[job] > highest_pref)
-			preview_job = SSjob.GetJob(job)
+		if(job_preferences[job] > highest_pref && SSjob.name_faction_occupations[job])
+			preview_job = SSjob.name_faction_occupations[job]
 			highest_pref = job_preferences[job]
 
 	return preview_job


### PR DESCRIPTION
## About The Pull Request

I forgot jobs are saved with their prefix now, so uh, let's account for that.

Also makes the default job be assistant instead of naked if you have no job prefs set.

## How Does This Help ***Gameplay***?

You can see what your job looks like now.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/4c745160-1e7f-40a5-bd05-77e4a0df0973)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Job previews now work again.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
