### PR TITLE
Chem Dispensers Are No Longer Powersinks

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -88,6 +88,7 @@
 			if(cartridge.reagents.is_reacting)//on_reaction_step() handles this
 				continue
 			var/thermal_energy_to_provide = (dispensed_temperature - cartridge.reagents.chem_temp) * (heater_coefficient * powerefficiency) * delta_time * SPECIFIC_HEAT_DEFAULT * cartridge.reagents.total_volume
+			thermal_energy_to_provide /= maximum_cartridges
 			// Okay, hear me out, one cartridge, when heated from default (room) temp to the magic water/ice temperature, provides about 255000 thermal energy (drinks dispenser, divide that by 10 for chem) a tick. Let's take that number, kneecap it down by a sizeable chunk, and use it as power consumption, yea?
 			power_to_use += abs(thermal_energy_to_provide) / 1000
 			cartridge.reagents.adjust_thermal_energy(thermal_energy_to_provide)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -1,6 +1,6 @@
 #define CHEM_DISPENSER_HEATER_COEFFICIENT 0.05
 // Soft drinks dispenser is much better at cooling cause of the specific temperature it wants water and ice at.
-#define SOFT_DISPENSER_HEATER_COEFFICIENT 0.5
+#define SOFT_DISPENSER_HEATER_COEFFICIENT 0.1
 
 /obj/machinery/chem_dispenser
 	name = "chem dispenser"


### PR DESCRIPTION
## About The Pull Request

Fixes a fuck up where drinks dispensers are using... *checks notes* 25x the amount of power they should've been. Uh... woops.

## How Does This Help ***Gameplay***?

Oh hey, the ship doesn't have a 30kw powersink on a reactor rated for 40kw!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Eventually

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Chem dispensers and chem machines no longer eat insane amounts of power.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
