### PR TITLE
[Port] Maintenance vent soulening

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -7,6 +7,9 @@
 /obj/effect/overlay/singularity_pull()
 	return
 
+/obj/effect/overlay/has_gravity(turf/gravity_turf)
+	return FALSE
+
 /obj/effect/overlay/beam//Not actually a projectile, just an effect.
 	name="beam"
 	icon='icons/effects/beam.dmi'
@@ -54,6 +57,21 @@
 	var/unused = 0
 	///overlays which go unused for this amount of time get cleaned up
 	var/cache_expiration = 2 MINUTES
+
+/obj/effect/overlay/vis/steam
+	plane = GRAVITY_PULSE_PLANE
+	alpha = 64
+	blend_mode = BLEND_ADD
+	/// Type of particle this uses
+	var/particle_type = /particles/smoke/steam/vent
+
+/obj/effect/overlay/vis/steam/Initialize(mapload)
+	. = ..()
+	if(particle_type)
+		particles = new particle_type()
+
+/obj/effect/overlay/vis/steam/heavy
+	particle_type = /particles/smoke/steam/vent/heavy
 
 /obj/effect/overlay/atmos_excited
 	name = "excited group"

--- a/code/game/objects/effects/particles/smoke.dm
+++ b/code/game/objects/effects/particles/smoke.dm
@@ -36,3 +36,9 @@
 	fade = 0.2 SECONDS
 	position = generator(GEN_VECTOR, list(-3, 5, 0), list(3, 6.5, 0), NORMAL_RAND)
 	velocity = generator(GEN_VECTOR, list(-0.1, 0.4, 0), list(0.1, 0.5, 0), NORMAL_RAND)
+
+/particles/smoke/steam/vent/heavy
+	spawning = 2
+	lifespan = 2 SECONDS
+	position = generator(GEN_SPHERE, 0, 10, NORMAL_RAND)
+	velocity = list(0, 0, 0)

--- a/code/game/objects/structures/maintenance.dm
+++ b/code/game/objects/structures/maintenance.dm
@@ -250,6 +250,8 @@ at the cost of risking a vicious bite.**/
 	name = "steam vent"
 	desc = "A device periodically filtering out moisture particles from the nearby walls and windows. It's only possible due to the moisture traps nearby."
 	icon_state = "steam_vent"
+	plane = FLOOR_PLANE
+	layer = ABOVE_OPEN_TURF_LAYER
 	anchored = TRUE
 	density = FALSE
 	/// How often does the vent reset the blow_steam cooldown.
@@ -258,6 +260,8 @@ at the cost of risking a vicious bite.**/
 	var/vent_active = TRUE
 	/// The cooldown for toggling the steam vent to prevent infinite steam vent looping.
 	COOLDOWN_DECLARE(steam_vent_interact)
+	/// Fun distortion effect for when the vent is active
+	var/obj/effect/overlay/vis/steam/steam = /obj/effect/overlay/vis/steam/heavy
 
 /obj/structure/steam_vent/Initialize(mapload)
 	. = ..()
@@ -267,7 +271,28 @@ at the cost of risking a vicious bite.**/
 		COMSIG_ATOM_EXIT = PROC_REF(blow_steam),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
-	update_icon_state()
+	if(steam)
+		steam = new steam()
+	update_appearance(UPDATE_ICON)
+
+/obj/structure/steam_vent/Destroy()
+	. = ..()
+	QDEL_NULL(steam)
+
+/obj/structure/steam_vent/update_icon(updates)
+	. = ..()
+
+	if(!steam)
+		return
+
+	if(vent_active)
+		vis_contents |= steam
+	else
+		vis_contents -= steam
+
+/obj/structure/steam_vent/update_icon_state()
+	. = ..()
+	icon_state = "steam_vent[vent_active ? "": "_off"]"
 
 /obj/structure/steam_vent/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
@@ -275,7 +300,7 @@ at the cost of risking a vicious bite.**/
 		balloon_alert(user, "not ready to adjust!")
 		return
 	vent_active = !vent_active
-	update_icon_state()
+	update_appearance(UPDATE_ICON)
 	if(vent_active)
 		balloon_alert(user, "vent on")
 	else
@@ -315,10 +340,6 @@ at the cost of risking a vicious bite.**/
 	smoke.start()
 	playsound(src, 'sound/machines/steam_hiss.ogg', 75, TRUE, -2)
 	COOLDOWN_START(src, steam_vent_interact, steam_speed)
-
-/obj/structure/steam_vent/update_icon_state()
-	. = ..()
-	icon_state = "steam_vent[vent_active ? "": "_off"]"
 
 /obj/structure/steam_vent/fast
 	desc = "A device periodically filtering out moisture particles from the nearby walls and windows. It's only possible due to the moisture traps nearby. It's faster than most."


### PR DESCRIPTION
## About The Pull Request

This pr is a port of the changes to vents in this PR:
- https://github.com/NovusSS13/NovusSS13/pull/157

This PR adds a cool distortion effect to the air above maintenance vents. The effect goes away when the vent is turned off. I'm only adding this for soul reasons and because the new map #562 has alot of these and it would add more soul to the map.

## How Does This Help ***Gameplay***?
Cooler things to look at during the gaming.

## How Does This Help ***Roleplay***?
Immersion.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/14f326ec-b078-43f3-92fc-bb751e44160a


</details>

## Changelog
:cl:
add: Maintenance vents now have a cool distortion effect for the air around them!
/:cl: