### PR TITLE
Make Opening PDAs Ignore Lighting Checks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -215,6 +215,8 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/offensive_notes
 	/// Used in obj/item/examine to determines whether or not to detail an item's statistics even if it does not meet the force requirements
 	var/override_notes = FALSE
+	/// If TRUE, ignores lighting checks for if this item can be read or not.
+	var/self_lighting = FALSE
 
 /obj/item/Initialize(mapload)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1142,7 +1142,7 @@
 		to_chat(src, span_warning("You can't write with the [writing_instrument]!"))
 		return FALSE
 
-	if(!has_light_nearby() && !has_nightvision())
+	if(!has_light_nearby() && !has_nightvision() && !writing_instrument.self_lighting)
 		to_chat(src, span_warning("It's too dark in here to write anything!"))
 		return FALSE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1142,7 +1142,7 @@
 		to_chat(src, span_warning("You can't write with the [writing_instrument]!"))
 		return FALSE
 
-	if(!has_light_nearby() && !has_nightvision() && !writing_instrument.self_lighting)
+	if(!has_light_nearby() && !has_nightvision())
 		to_chat(src, span_warning("It's too dark in here to write anything!"))
 		return FALSE
 
@@ -1176,6 +1176,11 @@
 /// Can this mob read
 /mob/proc/can_read(obj/O)
 	if(!has_light_nearby() && !has_nightvision())
+		if(isitem(O))
+			var/obj/item/item = O
+			if(item.self_lighting)
+				return TRUE
+
 		to_chat(src, span_warning("It's too dark in here to read!"))
 		return FALSE
 

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -25,6 +25,7 @@
 	has_light = TRUE //LED flashlight!
 	comp_light_luminosity = 2.3 //this is what old PDAs were set to
 	looping_sound = FALSE
+	self_lighting = TRUE
 
 	pickup_sound = 'sound/items/handling/device_pickup.ogg'
 	drop_sound = 'sound/items/handling/device_drop.ogg'


### PR DESCRIPTION
## About The Pull Request

:angery:

## How Does This Help ***Gameplay***?

THE SCREEN GLOWS, WHAT THE FUCK YOU MEAN I CAN'T READ THE FUCKING THING?!?!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->
I'll show when I get around to compiling it, testing other things atm.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: PDAs can now be read inside dark areas.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
