### PR TITLE
Halves Our Init Times By Disabling Unnecessary Zs

### DIFF
--- a/code/__DEFINES/overmap.dm
+++ b/code/__DEFINES/overmap.dm
@@ -1,3 +1,7 @@
+// Comment this out to enable planets and space Z generation.
+// Disabled by default cause we don't have the player count on live, and it adds a notable amount to init times.
+#define DISABLE_OVERMAP_ZS
+
 //Bitflags for overmap_flags
 #define OV_SHOWS_ON_SENSORS (1<<0)
 #define OV_CAN_BE_TARGETED (1<<1)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -414,9 +414,11 @@ Used by the AI doomsday and the self-destruct nuke.
 		qdel(query_round_map_name)
 
 #ifndef LOWMEMORYMODE
+	#ifndef DISABLE_OVERMAP_ZS
 	while (space_levels_so_far < config.space_ruin_levels)
 		++space_levels_so_far
 		add_new_zlevel("Ruins Area [space_levels_so_far]", ZTRAITS_SPACE, overmap_obj = new /datum/overmap_object/ruins(SSovermap.main_system, rand(1,SSovermap.main_system.maxx), rand(1,SSovermap.main_system.maxy)))
+	#endif
 	//Load planets
 	if(config.minetype == "lavaland")
 		var/datum/planet_template/lavaland_template = planet_templates[/datum/planet_template/lavaland]

--- a/code/modules/overmap/planets/planet_templates.dm
+++ b/code/modules/overmap/planets/planet_templates.dm
@@ -40,6 +40,7 @@
 	var/ore_node_seeder_type = /datum/ore_node_seeder
 
 /datum/planet_template/proc/LoadTemplate(datum/overmap_sun_system/system, coordinate_x, coordinate_y)
+	#ifndef DISABLE_OVERMAP_ZS
 	var/old_z = world.maxz
 	var/datum/overmap_object/linked_overmap_object = new overmap_type(system, coordinate_x, coordinate_y)
 	var/picked_rock_color = CHECK_AND_PICK_OR_NULL(rock_color)
@@ -73,6 +74,7 @@
 			WARNING("No area type passed on planet generation")
 		if(!generator_type)
 			WARNING("No generator type passed on planet generation")
+
 		var/datum/space_level/new_level = SSmapping.add_new_zlevel(name, default_traits_input, overmap_obj = linked_overmap_object)
 		if(picked_rock_color)
 			new_level.rock_color = picked_rock_color
@@ -113,6 +115,9 @@
 
 	//Pass them to the ruin seeder
 	SeedRuins(z_levels)
+	#else
+	return
+	#endif
 
 //Due to the particular way ruins are seeded right now this will be handled through a proc, rather than data-driven as of now
 /datum/planet_template/proc/SeedRuins(list/z_levels)


### PR DESCRIPTION
## About The Pull Request

This has been sat uncommitted on the 515 branch for longer than I'd like to admit, so here it is.

Disables space and planet Zs cause they are physically inaccessible on current code.

I should also probably drop the amount of them... oh well!

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/c7004526-6296-455a-877d-a62dfc2aae35)
</details>

## Changelog

Non-player facing.
