### PR TITLE
Make Roundend Shuttle Go Super Fast

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -1061,7 +1061,7 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/autoEnd()
 	if(EMERGENCY_IDLE_OR_RECALLED)
-		SSshuttle.emergency.request(silent = TRUE)
+		SSshuttle.emergency.request(silent = TRUE, set_coefficient = 0.5)
 		priority_announce("The shift has come to an end. The tranfer shuttle is en route. [SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/misc/announce_dig.ogg', "Priority")
 		log_game("Round end vote passed. Shuttle has been auto-called.")
 		message_admins("Round end vote passed. Shuttle has been auto-called.")


### PR DESCRIPTION
## About The Pull Request

Folk are usually wrapping up their RPs or whatever by this point, and 23 minutes is an awkward recall time for the shuttle, so let's drop that to 5.5 minute docking time.

## How Does This Help ***Gameplay***?

Less waiting for the roundend shuttle. Most folk are already finished with playing for the round by the time it arrives.

## How Does This Help ***Roleplay***?

No more awkwardly trying to squeeze in roleplay in a time that's too short to get into anything super complex, while still giving folk time to wrap up what they're doing.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

See playtest.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Shift end shuttle now arrives much faster.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
