### PR TITLE
[PORT] Lightswitch context and deconstruction from TG (PR#79416)

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -70,7 +70,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 /obj/machinery/light_switch/examine(mob/user)
 	. = ..()
 	. += "It is [(machine_stat & NOPOWER) ? "unpowered" : (area.lightswitch ? "on" : "off")]."
-	. += span_notice("It appears to be <b>screwed</b> in place.")
+	. += span_notice("It is <b>screwed</b> in place.")
 
 /obj/machinery/light_switch/interact(mob/user)
 	. = ..()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -43,7 +43,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 	if(isnull(held_item))
 		context[SCREENTIP_CONTEXT_LMB] = area.lightswitch ? "Flick off" : "Flick on"
 		return CONTEXTUAL_SCREENTIP_SET
-	if(held_item.tool_behaviour != TOOL_SCREWDRIVER)
+	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
 		context[SCREENTIP_CONTEXT_RMB] = "Deconstruct"
 		return CONTEXTUAL_SCREENTIP_SET
 	return .
@@ -70,6 +70,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 /obj/machinery/light_switch/examine(mob/user)
 	. = ..()
 	. += "It is [(machine_stat & NOPOWER) ? "unpowered" : (area.lightswitch ? "on" : "off")]."
+	. += span_notice("It appears to be <b>screwed</b> in place.")
 
 /obj/machinery/light_switch/interact(mob/user)
 	. = ..()
@@ -79,7 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 	if(weapon.tool_behaviour == TOOL_SCREWDRIVER)
 		to_chat(user, "You pop \the [src] off the wall.")
 		deconstruct()
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return FALSE
 	return ..()
 
 /obj/machinery/light_switch/proc/set_lights(status)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -80,7 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 	if(weapon.tool_behaviour == TOOL_SCREWDRIVER)
 		to_chat(user, "You pop \the [src] off the wall.")
 		deconstruct()
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	return ..()
 
 /obj/machinery/light_switch/proc/set_lights(status)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -33,7 +33,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 		area = get_area(src)
 
 	if(autoname)
-		name = "light switch ([area.name])"
+		name = "[area.name] light switch"
 
 	register_context()
 	update_appearance()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -80,7 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 	if(weapon.tool_behaviour == TOOL_SCREWDRIVER)
 		to_chat(user, "You pop \the [src] off the wall.")
 		deconstruct()
-		return FALSE
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 	return ..()
 
 /obj/machinery/light_switch/proc/set_lights(status)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -12,6 +12,8 @@
 	var/area/area = null
 	///Range of the light emitted when powered, but off
 	var/light_on_range = 1
+	/// Should this lightswitch automatically rename itself to match the area it's in?
+	var/autoname = TRUE
 
 /obj/machinery/light_switch/Initialize(mapload)
 	. = ..()
@@ -30,10 +32,21 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 	if(!area)
 		area = get_area(src)
 
-	if(!name)
+	if(autoname)
 		name = "light switch ([area.name])"
 
+	register_context()
 	update_appearance()
+
+/obj/machinery/light_switch/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = area.lightswitch ? "Flick off" : "Flick on"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(held_item.tool_behaviour != TOOL_SCREWDRIVER)
+		context[SCREENTIP_CONTEXT_RMB] = "Deconstruct"
+		return CONTEXTUAL_SCREENTIP_SET
+	return .
 
 /obj/machinery/light_switch/update_appearance(updates=ALL)
 	. = ..()
@@ -61,6 +74,13 @@ MAPPING_DIRECTIONAL_HELPERS_ROBUST(/obj/machinery/light_switch, 32, -18, 33, -33
 /obj/machinery/light_switch/interact(mob/user)
 	. = ..()
 	set_lights(!area.lightswitch)
+
+/obj/machinery/light_switch/attackby_secondary(obj/item/weapon, mob/user, params)
+	if(weapon.tool_behaviour == TOOL_SCREWDRIVER)
+		to_chat(user, "You pop \the [src] off the wall.")
+		deconstruct()
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/machinery/light_switch/proc/set_lights(status)
 	if(area.lightswitch == status)


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/79416 per Rimi's request with a change to the context logic (the deconstruct prompt now displays when you have the appropriate tool in hand) and the minor addition of an examine hint.

Original PR by [ArcaneMusic](https://github.com/ArcaneMusic).

<!-- Write **BELOW** The Headers and **ABOVE** The comments, else it may not be viewable. You may remove these comments. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- SEE THE CONTRIBUTING GUIDELINES AND ESPECIALLY THE FOLLOWING BEFORE MAKING A PR: https://github.com/Artea-Station/Artea-Station-Server/blob/master/.github/guides/RESTRICTED_PR_TOPICS.md -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>

Below has been updated since the screenshot to read "It is **screwed** in place." for consistency with other machines:
![examine](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/5c8ba8e1-7dc2-4882-8831-8f1ef533b3e3)

Image of the context prompt, the name autogenerated for lightswitches has since been tweaked to place the room name before the object, for consistency with APCs and alarms:
![context](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/34600ea4-7062-40f4-a72a-6b693fff4418)

Text displayed following a successful deconstruction:
![switchdecon](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/882878a4-72b2-4e49-9ebe-ba30138140d3)

<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Lightswitches can now be deconstructed: an examine hint and context have been added to aid in this.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
