### PR TITLE
Fix Holomaps Not Closing Automatically

### DIFF
--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -84,7 +84,7 @@
 
 	watching_mob = user // Do it here in case the map errors out while opening for whatever reason. Makes it easier for admins to force close the map.
 	if(holomap_datum.open_holomap(user, src))
-		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_position))
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(watcher_moved))
 		icon_state = "[initial(icon_state)]_active"
 		set_light(HOLOMAP_HIGH_LIGHT)
 		update_use_power(ACTIVE_POWER_USE)
@@ -99,13 +99,9 @@
 	if((machine_stat & (NOPOWER | BROKEN)) || !anchored)
 		close_map()
 
-/obj/machinery/holomap/proc/check_position()
+/obj/machinery/holomap/proc/watcher_moved()
 	SIGNAL_HANDLER
-	if(!watching_mob)
-		return
-
-	if(watching_mob.loc != loc)
-		close_map(watching_mob)
+	close_map(watching_mob)
 
 /obj/machinery/holomap/proc/close_map()
 	if(holomap_datum.close_holomap(src))

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -104,7 +104,7 @@
 	if(!watching_mob)
 		return
 
-	if(!Adjacent(watching_mob))
+	if(watching_mob.loc != loc)
 		close_map(watching_mob)
 
 /obj/machinery/holomap/proc/close_map()

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -65,10 +65,10 @@
 
 /obj/machinery/holomap/attack_hand(mob/user)
 	if(user && user == holomap_datum?.watching_mob)
-		holomap_datum.close_holomap(src)
+		close_map(src)
 		return
 
-	holomap_datum.open_holomap(user, src)
+	open_map(user, src)
 
 /// Tries to open the map for the given mob. Returns FALSE if it doesn't meet the criteria, TRUE if the map successfully opened with no runtimes.
 /obj/machinery/holomap/proc/open_map(mob/user)

--- a/code/modules/holomap/holomap.dm
+++ b/code/modules/holomap/holomap.dm
@@ -82,6 +82,7 @@
 
 	holomap_datum.update_map(handle_overlays())
 
+	watching_mob = user // Do it here in case the map errors out while opening for whatever reason. Makes it easier for admins to force close the map.
 	if(holomap_datum.open_holomap(user, src))
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_position))
 		icon_state = "[initial(icon_state)]_active"


### PR DESCRIPTION
## About The Pull Request

How the fuck did this not break for me for the longest time?

Anyways, holomaps now close again. Helps if you don't use the datum proc that doesn't handle the extra fluff checks.

## How Does This Help ***Gameplay***?

Shit now closes without manual intervention.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/94f97936-f25d-4881-9c23-e717d5eae0b7)
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/f85d19a8-4d4f-4c44-8a6b-8ea05b456392)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Holomaps should now autoclose properly.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
