### PR TITLE
[PORT] 'Laser decharge sound uses pitch instead of frequency' from TG (PR#83102)

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -44,18 +44,21 @@
 	// How many shots left before the energy gun's current battery runs out of energy
 	var/shots_left = 0
 	// What frequency the energy gun's sound will make
-	var/frequency_to_use = 0
+	var/pitch_to_use = 0
 
 	if(shot.e_cost > 0)
 		shot_cost_percent = FLOOR(clamp(shot.e_cost / cell.maxcharge, 0, 1) * 100, 1)
-		max_shots = round(100/shot_cost_percent)
-		shots_left = round(batt_percent/shot_cost_percent)
-		frequency_to_use = sin((90/max_shots) * shots_left)
+		max_shots = round(100/shot_cost_percent) - 1
+		shots_left = round(batt_percent/shot_cost_percent) - 1
+		pitch_to_use = LERP(1, 0.3, (1 - (shots_left/max_shots)) ** 2)
+
+	var/sound/playing_sound = sound(suppressed ? suppressed_sound : fire_sound)
+	playing_sound.pitch = pitch_to_use
 
 	if(suppressed)
-		playsound(src, suppressed_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0, frequency = frequency_to_use)
+		playsound(src, playing_sound, suppressed_volume, vary_fire_sound, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
 	else
-		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound, frequency = frequency_to_use)
+		playsound(src, playing_sound, fire_sound_volume, vary_fire_sound)
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/83102 per Rimi's request.

Original PR by [Jacquerel](https://github.com/Jacquerel).

<!-- Write **BELOW** The Headers and **ABOVE** The comments, else it may not be viewable. You may remove these comments. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- SEE THE CONTRIBUTING GUIDELINES AND ESPECIALLY THE FOLLOWING BEFORE MAKING A PR: https://github.com/Artea-Station/Artea-Station-Server/blob/master/.github/guides/RESTRICTED_PR_TOPICS.md -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
Tesla cannon drained by testing:
![tesladischarge](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/a268cdf2-2fc0-4b63-9f00-be91f0ba3f9f)

<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
sound: Lasers adjust their pitch as they run out of charge, rather than frequency.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
