### PR TITLE
[PORT] Unterminated speech now ends in a period, automatically! from Bubber (PRs #628 & #852)

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -97,7 +97,8 @@
 #define MSG_VISUAL (1<<0)
 #define MSG_AUDIBLE (1<<1)
 
-
-
 //Used in visible_message_flags, audible_message_flags and runechat_flags
 #define EMOTE_MESSAGE (1<<0)
+
+//Auto punctuation global datum
+GLOBAL_DATUM_INIT(has_eol_punctuation, /regex, regex(@"^(\w|^[^\*].*[^.!?~\-\+\|\_\*]+)$"))

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -100,5 +100,6 @@
 //Used in visible_message_flags, audible_message_flags and runechat_flags
 #define EMOTE_MESSAGE (1<<0)
 
-//Auto punctuation global datum
-GLOBAL_DATUM_INIT(has_eol_punctuation, /regex, regex(@"^(\w|^[^\*].*[^.!?~\-\+\|\_\*]+)$"))
+//Auto punctuation global datums
+GLOBAL_DATUM_INIT(has_no_eol_punctuation, /regex, regex("\\w$"))
+GLOBAL_DATUM_INIT(noncapital_i, /regex, regex("\\b\[i]\\b", "g"))

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -209,8 +209,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		return
 
 	//Handle auto-capitalization of isolated 'i's, adds a period to the end of unterminated inputs <-- like this one.
-	if(client?.autopunctuation)
-		message = autopunct_bare(message)
+	message = autopunct_bare(message)
 
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something
 	if(saymode && !saymode.handle_message(src, message, language))

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -98,6 +98,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(!message || message == "")
 		return
 
+	if(findtext(message, GLOB.has_eol_punctuation))
+		message += "."
+
 	var/list/message_mods = list()
 	var/original_message = message
 	message = get_message_mods(message, message_mods)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -98,9 +98,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(!message || message == "")
 		return
 
-	if(findtext(message, GLOB.has_eol_punctuation))
-		message += "."
-
 	var/list/message_mods = list()
 	var/original_message = message
 	message = get_message_mods(message, message_mods)
@@ -210,6 +207,10 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		if(succumbed)
 			succumb()
 		return
+
+	//Handle auto-capitalization of isolated 'i's, adds a period to the end of unterminated inputs <-- like this one.
+	if(client?.autopunctuation)
+		message = autopunct_bare(message)
 
 	//This is before anything that sends say a radio message, and after all important message type modifications, so you can scumb in alien chat or something
 	if(saymode && !saymode.handle_message(src, message, language))
@@ -488,3 +489,14 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(get_minds && mind)
 		return mind.get_language_holder()
 	. = ..()
+
+/**
+ * Ensures sentences end in a period if no other terminal punctuation is present
+ * and that all whitespace-bounded 'i' characters are capitalized.
+ */
+/mob/living/proc/autopunct_bare(input_text)
+	if (findtext(input_text, GLOB.has_no_eol_punctuation))
+		input_text += "."
+
+	input_text = replacetext(input_text, GLOB.noncapital_i, "I")
+	return input_text


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/Bubberstation/Bubberstation/pull/628 and https://github.com/Bubberstation/Bubberstation/pull/852 per Rimi's request.

Ported PRs by [ReturnToZender](https://github.com/ReturnToZender).

<!-- Write **BELOW** The Headers and **ABOVE** The comments, else it may not be viewable. You may remove these comments. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- SEE THE CONTRIBUTING GUIDELINES AND ESPECIALLY THE FOLLOWING BEFORE MAKING A PR: https://github.com/Artea-Station/Artea-Station-Server/blob/master/.github/guides/RESTRICTED_PR_TOPICS.md -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>

Testing unterminated speech:
(input)
![input](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/3a79d854-7e69-4bd0-98bb-7146166d3f0c)
(output)
![output1](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/5374a3da-cf9b-4235-a7d7-187f81b63cb5)
![output2](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/835b50f3-26b7-4c14-89d9-aaedd50a870d)

Testing terminated speech:
(input)
![input2](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/1ceb8e2c-7db8-4d88-b461-21933c2815f1)
(output)
![output3](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/8a6a2828-13d2-42ac-b59a-9bf67522249e)
![output4](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/97278487-2e6e-4f68-8bc9-be881362f87e)

Testing ' i ' --> ' I ':
(input)
![input3](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/e61a453a-abef-4c5a-9ddb-c84ad210d75a)
(output)
![output5](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/6d9e682e-bb35-415a-b39d-c56c5c0268e8)

Testing over comms:
(input)
![input4](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/a0b5ef0f-b3d8-4e53-b13f-8e910e16bebe)
(output)
![output6](https://github.com/Artea-Station/Artea-Station-Server/assets/53711771/23a388b5-f4bb-49ae-8476-4160752396db)

<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: Unterminated speech automatically receives a period and 'i' receives capitalization when bounded by whitespace on either side.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
