### PR TITLE
[PORT] The recoilening 

### DIFF
--- a/code/__HELPERS/animation.dm
+++ b/code/__HELPERS/animation.dm
@@ -1,0 +1,14 @@
+///Makes a recoil-like animation on the mob camera.
+/proc/recoil_camera(mob/M, duration, backtime_duration, strength, angle)
+	if(!M || !M.client)
+		return
+	var/client/sufferer = M.client
+	strength *= world.icon_size
+	var/oldx = sufferer.pixel_x
+	var/oldy = sufferer.pixel_y
+
+	//get pixels to move the camera in an angle
+	var/mpx = sin(angle) * strength
+	var/mpy = cos(angle) * strength
+	animate(sufferer, pixel_x = oldx+mpx, pixel_y = oldy+mpy, time = duration, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = oldx, pixel_y = oldy, time = backtime_duration, easing = BACK_EASING)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -49,7 +49,6 @@
 	var/suppressed_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
 	var/suppressed_volume = 60
 	var/can_unsuppress = TRUE
-	var/recoil = 0 //boom boom shake the room
 	var/clumsy_check = TRUE
 	var/obj/item/ammo_casing/chambered = null
 	trigger_guard = TRIGGER_GUARD_NORMAL //trigger guard on the weapon, hulks can't fire them with their big meaty fingers
@@ -84,6 +83,13 @@
 	var/ammo_y_offset = 0
 
 	var/pb_knockback = 0
+
+	///boom boom shake the room
+	var/recoil = 0
+	///a multiplier of the duration the recoil takes to go back to normal view, this is (recoil*recoil_backtime_multiplier)+1
+	var/recoil_backtime_multiplier = 2
+	///this is how much deviation the gun recoil can have, recoil pushes the screen towards the reverse angle you shot + some deviation which this is the max.
+	var/recoil_deviation = 22.5
 
 /obj/item/gun/Initialize(mapload)
 	. = ..()
@@ -171,8 +177,11 @@
 		playsound(src, fire_sound, fire_sound_volume, vary_fire_sound)
 
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
+	var/angle = get_angle(user, pbtarget)+rand(-recoil_deviation, recoil_deviation) + 180
+	if(angle > 360)
+		angle -= 360
 	if(recoil && !tk_firing(user))
-		shake_camera(user, recoil + 1, recoil)
+		recoil_camera(user, recoil+1, (recoil*recoil_backtime_multiplier) + 1, recoil, angle)
 	fire_sounds()
 	if(!suppressed)
 		if(message)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -118,6 +118,8 @@
 	var/misfire_percentage_increment = 0
 	///What is the cap on our misfire probability? Do not set this to 100.
 	var/misfire_probability_cap = 25
+	/// How much recoil the gun has.
+	recoil = 1
 
 /obj/item/gun/ballistic/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -33,6 +33,8 @@
 	var/use_cyborg_cell = FALSE
 	///set to true so the gun is given an empty cell
 	var/dead_cell = FALSE
+	/// How much recoil the gun has.
+	recoil = 0.2
 
 /obj/item/gun/energy/fire_sounds()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -26,6 +26,7 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	single_shot_type_overlay = FALSE
+	recoil = 0.1
 
 /obj/item/gun/energy/e_gun/mini/add_seclight_point()
 	// The mini energy gun's light comes attached but is unremovable.

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -32,6 +32,7 @@
 	inhand_icon_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 2
+	recoil = 0.1
 
 /obj/item/gun/energy/disabler/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -323,6 +323,7 @@
 #include "code\__HELPERS\_string_lists.dm"
 #include "code\__HELPERS\admin.dm"
 #include "code\__HELPERS\ai.dm"
+#include "code\__HELPERS\animation.dm"
 #include "code\__HELPERS\areas.dm"
 #include "code\__HELPERS\atmospherics.dm"
 #include "code\__HELPERS\atoms.dm"


### PR DESCRIPTION
## About The Pull Request
This pr is a port of: 
- https://github.com/Mojave-Sun/mojave-sun-13/pull/430

This PR significantly improves recoil (screenshake when shooting guns) because our current recoil sucks ass. Instead of a simple screenshake its now based on the direction you're shooting in. I have also gone ahead and added recoil values to the guns we have in-game right now.

Ballistic guns have a recoil value of `1`
Energy guns have a recoil value of `0.2`
Disablers and the Miniature energy gun have a recoil value of because they're tiny `0.1`

This is yet another expansion of the guns and other cool shit pr's like: #520 #455 and #460.

## How Does This Help ***Gameplay***?
Feedback to in game actions is always good and guns not having recoil when being shot is just weird.

## How Does This Help ***Roleplay***?
Immersion probably

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

## Old Recoil

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/3a483a6d-a98f-4ae7-a34e-f4b7750ac7c1

## New Recoil

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/6bcefbc4-3070-44f6-90ba-45638c99b553

## New recoil on a disabler

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/7ac9e71a-eebb-4be8-afc3-a971c3d2d013



</details>

## Changelog
:cl:
qol: Recoil is alot less awful now and is based on the direction you're shooting in. 
/:cl: