### PR TITLE
Bulkhead sound change.

### DIFF
--- a/code/game/machinery/doors/bulkhead.dm
+++ b/code/game/machinery/doors/bulkhead.dm
@@ -129,8 +129,8 @@
 	var/normalspeed = TRUE
 	var/cutAiWire = FALSE
 	var/autoname = FALSE
-	var/doorOpen = 'sound/machines/door/airlock_open.ogg'
-	var/doorClose = 'sound/machines/door/airlock_close.ogg'
+	var/doorOpen = 'sound/machines/door/airlock_open_maint.ogg'
+	var/doorClose = 'sound/machines/door/airlock_close_maint.ogg'
 	var/doorDeni = 'sound/machines/door/deniedbeep.ogg' // i'm thinkin' Deni's
 	var/boltUp = 'sound/machines/door/boltsup.ogg'
 	var/boltDown = 'sound/machines/door/boltsdown.ogg'

--- a/code/game/machinery/doors/bulkhead_types.dm
+++ b/code/game/machinery/doors/bulkhead_types.dm
@@ -38,8 +38,6 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_mai
 	normal_integrity = 250
 	stripe_paint = "#B69F3C"
-	doorOpen = 'sound/machines/door/airlock_open_maint.ogg'
-	doorClose = 'sound/machines/door/airlock_close_maint.ogg'
 
 /obj/machinery/door/bulkhead/maintenance/external
 	name = "external bulkhead access"


### PR DESCRIPTION
## About The Pull Request
Mini PR that changes the sound of bulkheads opening/closing.

Swapping the normal out for the one that is being used on maint bulkheads because it sounds cooler.
Visually the bulkheads look the same too so makes sense to give them the same sound right?

## How Does This Help ***Gameplay***?
Minimal impact on gameplay aside from a more distinct and unique sound for our bulkheads

## How Does This Help ***Roleplay***?
Minimal impact on RP unless this really adds to your immersion.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

## Old sound (Current)

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/66938bea-1b7b-456a-9f1d-6da04c3ef53f

## New sound (Much cooler)

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/a7a457a3-9a95-4cf7-a033-b6faff5761d7

</details>

## Changelog
:cl:
soundadd: Changed the sound of regular bulkheads to use the maint bulkhead sound (it just sounds better)
/:cl: