### PR TITLE
Maint lights dimmening

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -88,7 +88,7 @@
 	name = "glowing goo"
 	desc = "Jeez. I hope that's not for lunch."
 	icon_state = "greenglow"
-	light_power = 2
+	light_power = 1.5
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN
 	beauty = -300

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -88,7 +88,7 @@
 	name = "glowing goo"
 	desc = "Jeez. I hope that's not for lunch."
 	icon_state = "greenglow"
-	light_power = 3
+	light_power = 2
 	light_range = 2
 	light_color = LIGHT_COLOR_GREEN
 	beauty = -300

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -234,8 +234,9 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 10
-	light_range = 5
-	light_system = STATIC_LIGHT
+	light_range = 4
+	light_power = 1
+	light_system = MOVABLE_LIGHT
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
 	custom_materials = null

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -650,11 +650,12 @@
 	icon = 'icons/obj/lighting.dmi'
 	base_state = "floor" // base description and icon_state
 	icon_state = "floor"
-	brightness = 4
+	brightness = 2
 	layer = LOW_OBJ_LAYER
 	plane = FLOOR_PLANE
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
+	bulb_power = 0.4
 
 #undef NIGHTSHIFT_LIGHT_MODIFIER
 #undef NIGHTSHIFT_COLOR_MODIFIER

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -89,7 +89,7 @@
 /obj/machinery/light/small/maintenance
 	bulb_colour = "#e0a142"
 	nightshift_allowed = FALSE
-	bulb_power = 0.8
+	bulb_power = 0.3
 
 // -------- Directional presets
 // The directions are backwards on the lights we have now


### PR DESCRIPTION
## About The Pull Request
Small tweak to maint lights and green glowing puddles.

Changed some of their values so they're a lot less bright because previously maint lights were brighter than their normal counterparts.
Floor lights have also been dimmed slightly

Having it like this looks better if you ask me. Before and after videos can be found in proof of testing.

## How Does This Help ***Gameplay***?
Its harder to see things now in maints now.

## How Does This Help ***Roleplay***?
Immersion probably.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

## Before

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/feab644d-71e8-4170-b65b-fa2bd925451b

## After

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/9e1af126-75ba-4e04-84a5-839589c720d3

</details>

## Changelog
:cl:
code: Floor lights, maintenance lights and green glowing puddles are alot less bright now
balance: Desk lamps are no longer brighter than the sun.
/:cl: