### PR TITLE
Belryth shuttering and mini fixes.

### DIFF
--- a/_maps/map_files/ALV Belryth/ALV Belryth.dmm
+++ b/_maps/map_files/ALV Belryth/ALV Belryth.dmm
@@ -103,6 +103,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/holomap/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/security/brig)
 "adi" = (
@@ -1270,6 +1271,7 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/holomap/engineering/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "aEf" = (
@@ -1431,6 +1433,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/holomap/engineering/directional/west,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/office)
 "aHk" = (
@@ -1909,6 +1912,11 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/pathfinders/greater)
+"aUi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/directional/south,
+/turf/open/floor/iron/textured,
+/area/station/hallway/primary/central/starboard)
 "aUD" = (
 /obj/effect/mapping_helpers/paint_wall/pathfinders,
 /turf/closed/wall/r_wall,
@@ -2963,6 +2971,7 @@
 "bse" = (
 /obj/effect/turf_decal/stripes/orange/corner,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
 "bsf" = (
@@ -4935,8 +4944,7 @@
 /obj/effect/mapping_helpers/paint_wall/bridge,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
-	id = "bridgelockdown";
-	dir = 4
+	id = "bridgelockdown"
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
@@ -5370,6 +5378,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/holomap/engineering/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/hallway)
 "cxb" = (
@@ -6073,16 +6082,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
-"cPa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firehead,
-/obj/effect/mapping_helpers/paint_wall/bridge,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridgelockdown"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "cPq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -7886,6 +7885,7 @@
 	},
 /obj/effect/turf_decal/box/orange,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/holomap/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/lobby)
 "dAu" = (
@@ -12861,6 +12861,7 @@
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/box/orange,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/port)
 "fQd" = (
@@ -14864,6 +14865,14 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"gGx" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "gGy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -17016,6 +17025,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/central/fore)
 "hCd" = (
@@ -20249,6 +20259,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"iPt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firehead,
+/obj/effect/mapping_helpers/paint_wall/bridge,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "iPC" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/effect/turf_decal/siding/blue,
@@ -22289,6 +22310,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical/central)
+"jCr" = (
+/obj/machinery/holomap/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/pathfinders/pathfinders_hallway)
 "jCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -23364,6 +23389,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/oil,
+/obj/machinery/holomap/directional/east,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central/aft)
 "jZS" = (
@@ -24484,6 +24510,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/orange/corner,
+/obj/machinery/holomap/directional/east,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central/fore)
 "kzI" = (
@@ -24606,14 +24633,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lower)
-"kBN" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "kCa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -25052,6 +25071,7 @@
 /area/station/medical/break_room)
 "kKL" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/pathfinders/pathfinders_hallway)
 "kKS" = (
@@ -25438,6 +25458,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"kSn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/holomap/directional/west,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/aft)
 "kSq" = (
 /obj/effect/turf_decal/stripes/orange/line{
 	dir = 5
@@ -25574,6 +25600,7 @@
 	dir = 5
 	},
 /obj/machinery/vending/coffee,
+/obj/machinery/holomap/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/command/internal_affairs_office)
 "kXS" = (
@@ -26406,6 +26433,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/spawner/random/trash/garbage,
+/obj/machinery/holomap/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/medical/central)
 "lsH" = (
@@ -32356,6 +32384,7 @@
 /obj/item/clipboard,
 /obj/item/toy/nuke,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/engineering/directional/south,
 /turf/open/floor/circuit/red,
 /area/station/engineering/reactor_control)
 "nQb" = (
@@ -33687,6 +33716,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central/port)
 "ora" = (
@@ -34924,6 +34954,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/textured/telecomms,
 /area/station/tcommsat/server)
+"oOQ" = (
+/obj/machinery/holomap/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/pathfinders/pathfinders_hallway)
 "oPe" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -41414,6 +41448,7 @@
 /obj/item/storage/medkit/regular,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
 "rAP" = (
@@ -41618,6 +41653,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central/starboard)
 "rEK" = (
@@ -42909,6 +42945,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"seZ" = (
+/obj/effect/turf_decal/stripes/orange/corner{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/pathfinders/pathfinders_hallway)
 "sfe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -43544,6 +43587,7 @@
 /obj/effect/turf_decal/box,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/engineering/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "ssJ" = (
@@ -44829,6 +44873,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/holomap/directional/west,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
 "tbP" = (
@@ -45344,6 +45389,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "tlS" = (
@@ -46067,6 +46113,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holomap/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/pathfinders/storage)
 "tBw" = (
@@ -47520,6 +47567,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/holomap/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/upper)
 "uhb" = (
@@ -48650,6 +48698,7 @@
 /obj/machinery/vending/drugs,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/treatment_center)
 "uHv" = (
@@ -83452,7 +83501,7 @@ oDm
 agf
 lAG
 nQo
-dYI
+kSn
 gEN
 axb
 xay
@@ -150303,7 +150352,7 @@ oaC
 djB
 rkw
 kaL
-lxm
+aUi
 oLY
 mkg
 rWf
@@ -153125,7 +153174,7 @@ hfb
 bHI
 wDz
 muh
-kBN
+gGx
 rEs
 eeT
 muY
@@ -215055,7 +215104,7 @@ sVp
 cSw
 uYr
 lFu
-lDl
+jCr
 rcj
 rcj
 gwP
@@ -216852,7 +216901,7 @@ cSw
 cSw
 cSw
 cSw
-uYr
+oOQ
 siO
 lDl
 qpO
@@ -217109,7 +217158,7 @@ cSw
 jvC
 iDr
 cSw
-bHh
+seZ
 kyx
 wBm
 gUY
@@ -230223,7 +230272,7 @@ vWZ
 wea
 gcP
 loC
-cPa
+clX
 iwi
 iwi
 iwi
@@ -230470,7 +230519,7 @@ iwi
 iwi
 iwi
 iwi
-cPa
+clX
 eKo
 nAI
 vwu
@@ -230480,7 +230529,7 @@ pKP
 xuc
 kFL
 mWG
-cPa
+clX
 iwi
 iwi
 iwi
@@ -230727,7 +230776,7 @@ iwi
 iwi
 iwi
 iwi
-cPa
+clX
 lCe
 kIU
 vwu
@@ -231757,13 +231806,13 @@ iwi
 iwi
 iwi
 otF
-clX
-clX
+iPt
+iPt
 gZv
 mrq
 ndm
-clX
-clX
+iPt
+iPt
 otF
 iwi
 iwi
@@ -232015,11 +232064,11 @@ iwi
 iwi
 iwi
 iwi
-cPa
 clX
+iPt
+iPt
+iPt
 clX
-clX
-cPa
 iwi
 iwi
 iwi

--- a/_maps/map_files/ALV Belryth/ALV Belryth.dmm
+++ b/_maps/map_files/ALV Belryth/ALV Belryth.dmm
@@ -763,6 +763,9 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/keycard_auth/directional/north{
+	pixel_y = 31
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
 "arY" = (
@@ -1419,6 +1422,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/hos)
 "aHg" = (
@@ -1984,6 +1988,10 @@
 /obj/machinery/door/window/left/directional/north{
 	req_access = list("medical");
 	name = "Medbay Desk"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "medoffice"
 	},
 /turf/open/floor/plating,
 /area/station/medical/office)
@@ -2607,6 +2615,11 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/paint_wall/cargo,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	name = "Privacy Shutters";
+	id = "cargoofficeshutter"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "bkS" = (
@@ -3210,13 +3223,13 @@
 /obj/machinery/door/firehead{
 	dir = 8
 	},
-/obj/machinery/door/bulkhead/mining/glass{
-	name = "Cargo Office";
-	dir = 4
-	},
 /obj/effect/mapping_helpers/bulkhead/access/all/supply/general,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/bulkhead/mining{
+	name = "Cargo Office";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -4310,10 +4323,10 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "cap" = (
@@ -4777,7 +4790,8 @@
 /area/station/maintenance/department/medical/central)
 "cjU" = (
 /obj/machinery/door/bulkhead/security{
-	dir = 8
+	dir = 8;
+	name = "Security Desk"
 	},
 /obj/machinery/door/firehead{
 	dir = 8
@@ -4920,6 +4934,10 @@
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/bridge,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "cmF" = (
@@ -5622,7 +5640,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/security,
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/machinery/door/poddoor/shutters{
 	id = "detshutter";
 	name = "Privacy Shutters"
 	},
@@ -5677,6 +5695,11 @@
 	},
 /obj/effect/mapping_helpers/paint_wall/cargo,
 /obj/effect/mapping_helpers/damaged_window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	name = "Privacy Shutters";
+	id = "cargoofficeshutter"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "cFP" = (
@@ -6050,6 +6073,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/upper)
+"cPa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firehead,
+/obj/effect/mapping_helpers/paint_wall/bridge,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "cPq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -6098,6 +6131,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/brig)
 "cPF" = (
@@ -7354,7 +7388,16 @@
 /area/station/commons/lounge)
 "dqU" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 1;
+	pixel_x = 7
+	},
+/obj/machinery/button/door{
+	pixel_y = -1;
+	pixel_x = -5;
+	id = "iaashutter";
+	name = "Shutters Control Button"
+	},
 /turf/open/floor/carpet/green,
 /area/station/command/internal_affairs_office)
 "drb" = (
@@ -8906,6 +8949,7 @@
 	fax_name = "Lead Pathfinders Office";
 	name = "Lead Pathfinders Fax Machine"
 	},
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/pathfinders/lead_office)
 "edi" = (
@@ -9389,6 +9433,11 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/button/door/directional/south{
+	pixel_x = -5;
+	name = "Shutters Control Button";
+	id = "medoffice"
+	},
 /turf/open/floor/plating,
 /area/station/medical/office)
 "eoN" = (
@@ -11446,6 +11495,10 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown";
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/command/bridge)
 "fkG" = (
@@ -12480,6 +12533,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/button/door/directional/west{
+	pixel_y = 10;
+	id = "chemshutter2";
+	name = "Shutters Control Button"
+	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "fIr" = (
@@ -13800,6 +13858,10 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchenshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen)
 "gje" = (
@@ -15022,6 +15084,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/medical,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "medoffice"
+	},
 /turf/open/floor/plating,
 /area/station/medical/office)
 "gMt" = (
@@ -15253,6 +15319,11 @@
 	},
 /obj/machinery/door/firehead{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	name = "Privacy Shutters";
+	id = "cargoofficeshutter"
 	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
@@ -18416,14 +18487,14 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/bulkhead/maintenance{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/bulkhead/medical{
+	name = "Maintenance Access"
+	},
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "igu" = (
@@ -19215,6 +19286,9 @@
 "ixA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenshutter"
+	},
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "ixK" = (
@@ -23401,6 +23475,10 @@
 /obj/effect/mapping_helpers/paint_wall/security,
 /obj/effect/mapping_helpers/damaged_window,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "secdeskshutter"
+	},
 /turf/open/floor/plating,
 /area/station/security/desk)
 "keb" = (
@@ -24250,6 +24328,11 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/button/door/directional/north{
+	pixel_x = 10;
+	name = "Shutters Control Button";
+	id = "chemshutter1"
+	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "kxu" = (
@@ -24523,6 +24606,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lower)
+"kBN" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "kCa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -26867,6 +26958,10 @@
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/medical,
 /obj/effect/mapping_helpers/damaged_window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "medoffice"
+	},
 /turf/open/floor/plating,
 /area/station/medical/office)
 "lEz" = (
@@ -26951,6 +27046,10 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchenshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen)
 "lGw" = (
@@ -27396,12 +27495,12 @@
 /turf/open/floor/wood,
 /area/station/medical/break_room)
 "lOS" = (
-/obj/machinery/door/bulkhead/command/glass{
-	name = "Internal Affairs Office"
-	},
 /obj/effect/mapping_helpers/bulkhead/access/all/command/internal_affairs,
 /obj/machinery/door/firehead,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/bulkhead/command{
+	name = "Internal Affairs Office"
+	},
 /turf/open/floor/wood,
 /area/station/command/internal_affairs_office)
 "lOZ" = (
@@ -28450,6 +28549,10 @@
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/security,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "secdeskshutter"
+	},
 /turf/open/floor/plating,
 /area/station/security/desk)
 "mmY" = (
@@ -28576,6 +28679,10 @@
 	},
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_y = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "barshutter"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
@@ -28839,6 +28946,10 @@
 /obj/machinery/door/window/right/directional/north{
 	req_access = list("medical");
 	name = "Medbay Desk"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "medoffice"
 	},
 /turf/open/floor/plating,
 /area/station/medical/office)
@@ -30382,6 +30493,10 @@
 	pixel_x = -8
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "secdeskshutter"
+	},
 /turf/open/floor/plating,
 /area/station/security/desk)
 "mXn" = (
@@ -30493,6 +30608,9 @@
 /obj/effect/mapping_helpers/damaged_window,
 /obj/effect/mapping_helpers/paint_wall/bridge,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown"
+	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "naJ" = (
@@ -33434,6 +33552,10 @@
 	pixel_y = -3;
 	pixel_x = -2
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchenshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen)
 "ond" = (
@@ -35618,6 +35740,12 @@
 	name = "CondiMaster Neo"
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/button/door/directional/west{
+	pixel_y = 3;
+	pixel_x = -23;
+	id = "kitchenshutter";
+	name = "Shutters Control Button"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen)
 "pez" = (
@@ -35908,6 +36036,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/bridge,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Privacy Shutters";
+	id = "iaashutter"
+	},
 /turf/open/floor/plating,
 /area/station/command/internal_affairs_office)
 "pjU" = (
@@ -37455,13 +37587,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "pWR" = (
-/obj/machinery/door/bulkhead/security/glass,
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/bulkhead/access/all/security/general,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/bulkhead/security{
+	name = "Security Desk"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/desk)
 "pXa" = (
@@ -38143,6 +38277,11 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/paint_wall/medical,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	name = "Privacy Shutters";
+	id = "chemshutter2"
+	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "qmf" = (
@@ -38835,10 +38974,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/meter/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/aft)
 "qAo" = (
@@ -39272,6 +39411,11 @@
 	},
 /obj/item/pen{
 	pixel_x = -6
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	name = "Privacy Shutters";
+	id = "chemshutter1"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -41357,7 +41501,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/paint_wall/security,
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/machinery/door/poddoor/shutters{
 	id = "detshutter";
 	name = "Privacy Shutters";
 	dir = 4
@@ -41463,6 +41607,10 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/trash/food_packaging,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "kitchenshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen)
 "rEF" = (
@@ -41579,6 +41727,10 @@
 	dir = 6
 	},
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "barshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
 "rGx" = (
@@ -44046,6 +44198,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
 /obj/effect/mapping_helpers/damaged_window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenshutter"
+	},
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "sOI" = (
@@ -44121,8 +44276,7 @@
 /obj/machinery/button/door/directional/north{
 	id = "engishutter";
 	name = "Shutters Control";
-	pixel_y = 28;
-	pixel_x = 4
+	pixel_y = 28
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
@@ -44554,15 +44708,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "sZm" = (
-/obj/machinery/door/bulkhead/security/glass,
 /obj/effect/mapping_helpers/bulkhead/access/all/security/detective,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firehead,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "detshutter";
-	name = "Privacy Shutters"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/bulkhead/security{
+	name = "Detective Office"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/detectives_office)
 "sZE" = (
@@ -47834,6 +47986,9 @@
 "uqh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firehead,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutter"
+	},
 /turf/open/floor/plating,
 /area/station/service/bar)
 "uqn" = (
@@ -48086,6 +48241,10 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown";
+	dir = 4
+	},
 /turf/open/floor/engine/airless,
 /area/station/command/bridge)
 "uxQ" = (
@@ -48255,9 +48414,17 @@
 "uBR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/keycard_auth/directional{
-	pixel_y = 5
+	pixel_y = 2;
+	pixel_x = -5
 	},
 /obj/effect/turf_decal/bot_orange,
+/obj/machinery/button/door{
+	name = "Bridge Lockdown";
+	id = "bridgelockdown";
+	pixel_y = 2;
+	pixel_x = 8;
+	req_access = list("command")
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
 "uBS" = (
@@ -48733,6 +48900,10 @@
 "uLH" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/button/door/directional/west{
+	name = "Shutters Control Button";
+	id = "barshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
 "uLQ" = (
@@ -48831,6 +49002,7 @@
 "uNl" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/bot,
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
 "uOg" = (
@@ -48934,6 +49106,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/keycard_auth/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/qm)
 "uQh" = (
@@ -49446,6 +49619,11 @@
 	},
 /obj/item/pen{
 	pixel_x = -6
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	name = "Privacy Shutters";
+	id = "chemshutter2"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -51482,6 +51660,10 @@
 	},
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "barshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
 "vXx" = (
@@ -51600,6 +51782,11 @@
 /obj/effect/mapping_helpers/paint_wall/medical,
 /obj/machinery/door/firehead{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	name = "Privacy Shutters";
+	id = "chemshutter1"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -53927,6 +54114,10 @@
 	pixel_y = -3;
 	pixel_x = -2
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "barshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
 "wXQ" = (
@@ -54543,6 +54734,10 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	id = "cargoofficeshutter";
+	name = "Shutters Control Button"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/office)
 "xlJ" = (
@@ -54738,6 +54933,11 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	pixel_x = 5;
+	name = "Shutters Control Button";
+	id = "secdeskshutter"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/desk)
 "xqq" = (
@@ -152925,7 +153125,7 @@ hfb
 bHI
 wDz
 muh
-wpQ
+kBN
 rEs
 eeT
 muY
@@ -230023,7 +230223,7 @@ vWZ
 wea
 gcP
 loC
-clX
+cPa
 iwi
 iwi
 iwi
@@ -230270,7 +230470,7 @@ iwi
 iwi
 iwi
 iwi
-clX
+cPa
 eKo
 nAI
 vwu
@@ -230280,7 +230480,7 @@ pKP
 xuc
 kFL
 mWG
-clX
+cPa
 iwi
 iwi
 iwi
@@ -230527,7 +230727,7 @@ iwi
 iwi
 iwi
 iwi
-clX
+cPa
 lCe
 kIU
 vwu
@@ -231815,11 +232015,11 @@ iwi
 iwi
 iwi
 iwi
+cPa
 clX
 clX
 clX
-clX
-clX
+cPa
 iwi
 iwi
 iwi

--- a/_maps/map_files/ALV Belryth/ALV Belryth.dmm
+++ b/_maps/map_files/ALV Belryth/ALV Belryth.dmm
@@ -1912,11 +1912,6 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/pathfinders/greater)
-"aUi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/holomap/directional/south,
-/turf/open/floor/iron/textured,
-/area/station/hallway/primary/central/starboard)
 "aUD" = (
 /obj/effect/mapping_helpers/paint_wall/pathfinders,
 /turf/closed/wall/r_wall,
@@ -4070,6 +4065,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/brig)
+"bQU" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "bQY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -5175,6 +5178,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/pathfinders/pathfinders_hallway)
+"crK" = (
+/obj/machinery/holomap/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/pathfinders/pathfinders_hallway)
 "cst" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -5378,7 +5385,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/holomap/engineering/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/hallway)
 "cxb" = (
@@ -14865,14 +14871,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"gGx" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "gGy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -20259,17 +20257,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
-"iPt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firehead,
-/obj/effect/mapping_helpers/paint_wall/bridge,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridgelockdown";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "iPC" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/effect/turf_decal/siding/blue,
@@ -22310,10 +22297,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical/central)
-"jCr" = (
-/obj/machinery/holomap/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/pathfinders/pathfinders_hallway)
 "jCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -23322,7 +23305,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/trash/garbage,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/holomap/engineering/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/engineering/hallway)
 "jXU" = (
@@ -25458,12 +25441,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"kSn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/holomap/directional/west,
-/turf/open/floor/plating,
-/area/station/hallway/primary/central/aft)
 "kSq" = (
 /obj/effect/turf_decal/stripes/orange/line{
 	dir = 5
@@ -29797,6 +29774,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/command)
+"mKD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holomap/directional/south,
+/turf/open/floor/iron/textured,
+/area/station/hallway/primary/central/starboard)
 "mKY" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/turf_decal/siding/blue/corner{
@@ -32131,6 +32113,10 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"nHU" = (
+/obj/machinery/holomap/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/pathfinders/pathfinders_hallway)
 "nIg" = (
 /turf/closed/wall/mineral/titanium,
 /area/station/maintenance/department/security/upper)
@@ -33710,6 +33696,12 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central/port)
+"oqq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/holomap/directional/west,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/aft)
 "oqz" = (
 /obj/effect/turf_decal/stripes/orange/line,
 /obj/effect/turf_decal/stripes/orange/corner{
@@ -34954,10 +34946,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/textured/telecomms,
 /area/station/tcommsat/server)
-"oOQ" = (
-/obj/machinery/holomap/directional/north,
-/turf/open/floor/iron/smooth,
-/area/station/pathfinders/pathfinders_hallway)
 "oPe" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -35819,6 +35807,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured,
 /area/station/hallway/primary/central/fore)
+"peU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firehead,
+/obj/effect/mapping_helpers/paint_wall/bridge,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgelockdown";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "peY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -42945,13 +42944,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
-"seZ" = (
-/obj/effect/turf_decal/stripes/orange/corner{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/smooth,
-/area/station/pathfinders/pathfinders_hallway)
 "sfe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -43927,6 +43919,13 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/pathfinders/storage)
+"sEC" = (
+/obj/effect/turf_decal/stripes/orange/corner{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/pathfinders/pathfinders_hallway)
 "sFt" = (
 /obj/effect/turf_decal/siding/red,
 /obj/machinery/holopad,
@@ -83501,7 +83500,7 @@ oDm
 agf
 lAG
 nQo
-kSn
+oqq
 gEN
 axb
 xay
@@ -150352,7 +150351,7 @@ oaC
 djB
 rkw
 kaL
-aUi
+mKD
 oLY
 mkg
 rWf
@@ -153174,7 +153173,7 @@ hfb
 bHI
 wDz
 muh
-gGx
+bQU
 rEs
 eeT
 muY
@@ -215104,7 +215103,7 @@ sVp
 cSw
 uYr
 lFu
-jCr
+nHU
 rcj
 rcj
 gwP
@@ -216901,7 +216900,7 @@ cSw
 cSw
 cSw
 cSw
-oOQ
+crK
 siO
 lDl
 qpO
@@ -217158,7 +217157,7 @@ cSw
 jvC
 iDr
 cSw
-seZ
+sEC
 kyx
 wBm
 gUY
@@ -231806,13 +231805,13 @@ iwi
 iwi
 iwi
 otF
-iPt
-iPt
+peU
+peU
 gZv
 mrq
 ndm
-iPt
-iPt
+peU
+peU
 otF
 iwi
 iwi
@@ -232065,9 +232064,9 @@ iwi
 iwi
 iwi
 clX
-iPt
-iPt
-iPt
+peU
+peU
+peU
 clX
 iwi
 iwi

--- a/_maps/map_files/ALV Belryth/ALV Belryth.dmm
+++ b/_maps/map_files/ALV Belryth/ALV Belryth.dmm
@@ -75,6 +75,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
 "acG" = (
@@ -22381,10 +22382,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/bulkhead/mining/glass{
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/bulkhead/mining{
 	name = "Hangar (DO NOT ENTER)"
 	},
-/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo/hangar)
 "jDE" = (
@@ -26535,6 +26536,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "luH" = (


### PR DESCRIPTION
## About The Pull Request
Small fixes on Belryth and additions of things I forgot

### Fixes include:
- A missing cable near sec
- All Head offices now have Key auth devices
- The bridge now has a lockdown button and blast doors
- Holomaps have been added in the hallways and other places throughout the ship.

**Shutters have been added to the following locations:**
- Security desk
- The Kitchen
- The Bar
- Cargo Office
- Iaa Office
- Chem
- Medical Office

I'm not providing screenshots or video of every single thing I fixed so just trust me that it works.

## How Does This Help ***Gameplay***?
Map qol is nice, like being able to close shutters on some annoying people at a departments desk.

## How Does This Help ***Roleplay***?
Properly finished maps are better for RP.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/ac8973ce-5621-43be-a50b-043bd4022bf1)


</details>

## Changelog
:cl:
add: ALV Belryth has been fitted with more privacy shutters in various locations!
/:cl: