### PR TITLE
Saves 34s of Init Time By Fucking Setting Waitfor on Airlock Init To False

### DIFF
--- a/code/game/machinery/airlock/custom_airlock_controller.dm
+++ b/code/game/machinery/airlock/custom_airlock_controller.dm
@@ -82,6 +82,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	icon_state = "doorin"
 
 /obj/effect/mapping_helpers/airlock_controller_helper/airlock/interior/payload(obj/machinery/door/bulkhead/airlock)
+	set waitfor = FALSE
 	airlock.id_tag = "custom_airlock_interior_[base_tag_name]"
 	airlock.set_frequency(FREQ_AIRLOCK_CONTROL)
 	airlock.close(TRUE)
@@ -92,6 +93,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	icon_state = "doorout"
 
 /obj/effect/mapping_helpers/airlock_controller_helper/airlock/exterior/payload(obj/machinery/door/bulkhead/airlock)
+	set waitfor = FALSE
 	airlock.id_tag = "custom_airlock_exterior_[base_tag_name]"
 	airlock.set_frequency(FREQ_AIRLOCK_CONTROL)
 	airlock.open(TRUE)
@@ -101,6 +103,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	affected_type = /obj/machinery/airlock_sensor
 
 /obj/effect/mapping_helpers/airlock_controller_helper/sensor/payload(obj/machinery/airlock_sensor/sensor)
+	set waitfor = FALSE
 	sensor.frequency = FREQ_AIRLOCK_CONTROL
 	sensor.master_tag = "custom_airlock_controller_[base_tag_name]"
 
@@ -109,6 +112,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	icon_state = "sens"
 
 /obj/effect/mapping_helpers/airlock_controller_helper/sensor/chamber/payload(obj/machinery/airlock_sensor/sensor)
+	set waitfor = FALSE
 	. = ..()
 	sensor.id_tag = "custom_airlock_sensor_chamber_[base_tag_name]"
 
@@ -117,6 +121,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	icon_state = "sensin"
 
 /obj/effect/mapping_helpers/airlock_controller_helper/sensor/interior/payload(obj/machinery/airlock_sensor/sensor)
+	set waitfor = FALSE
 	. = ..()
 	sensor.id_tag = "custom_airlock_sensor_interior_[base_tag_name]"
 
@@ -129,6 +134,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	icon_state = "sensout"
 
 /obj/effect/mapping_helpers/airlock_controller_helper/sensor/exterior/payload(obj/machinery/airlock_sensor/sensor)
+	set waitfor = FALSE
 	. = ..()
 	sensor.id_tag = "custom_airlock_sensor_exterior_[base_tag_name]"
 
@@ -142,6 +148,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airlock_controller/autoset/hallway, 2
 	affected_type = /obj/machinery/atmospherics/components/binary/dp_vent_pump
 
 /obj/effect/mapping_helpers/airlock_controller_helper/pump/payload(obj/machinery/atmospherics/components/binary/dp_vent_pump/pump)
+	set waitfor = FALSE
 	pump.id_tag = "custom_airlock_pump_[base_tag_name]"
 	pump.frequency = FREQ_AIRLOCK_CONTROL
 


### PR DESCRIPTION
## About The Pull Request

AMATEUR HOUR, AMATEUR HOUR

## How Does This Help ***Gameplay***?

34s less init on belryth, ~8s less init on bearcat. Fuck me, I did this in the branch that had newairlocks, and never fucking committed it.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

OLD
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/0a490e86-e297-4392-906f-dacbbdd9e55f)
NEW
![image](https://github.com/Artea-Station/Artea-Station-Server/assets/106692773/4f299c37-d31b-464d-8b57-4024e58e6ab8)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

Non-player facing.

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
