### PR TITLE
Wall Integrity buff

### DIFF
--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -74,7 +74,7 @@ GLOBAL_REAL_VAR(wall_overlays_cache) = list()
 	VAR_PRIVATE/cache_key
 
 	// Vars for bullet hitting wall interactions
-	max_integrity = 100 // Most common ballistics deal 20-30 damage a shot.
+	max_integrity = 300 // Most common ballistics deal 20-30 damage a shot.
 	damage_deflection = 5
 
 /turf/closed/wall/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)


### PR DESCRIPTION
## About The Pull Request

Buffs the integrity of walls from 100 to 300.

Making this PR because right now its way to easy to tunnel through walls with ballistics, increasing the health of walls will help with preventing this.

## How Does This Help ***Gameplay***?
You can no longer tunnel through walls with an L6. This is good for obvious reasons.

## How Does This Help ***Roleplay***?
Minimal impact on RP.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

## Before

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/fee9a14b-7e39-4a64-b000-ae173b6fa21e

## After

https://github.com/Artea-Station/Artea-Station-Server/assets/79924768/d64e36fa-f2c2-4b87-be8d-7514d09d583f




</details>

## Changelog
:cl:
balance: Buffed wall integrity from 100 to 300.
/:cl: