### PR TITLE
Fix Railings Having The Wrong Layer

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -26,6 +26,7 @@
 		AddElement(/datum/element/connect_loc, loc_connections)
 
 	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM, CALLBACK(src, PROC_REF(on_rotation)))
+	on_rotation()
 
 /obj/structure/railing/proc/on_rotation()
 	if((NORTH | SOUTH) & dir)


### PR DESCRIPTION
## About The Pull Request

I forgot to actually call the on_rotation proc when adding it in, so the railings just always had the wrong layer unless someone rotated them.

It's not perfect, but it looks a hell of a lot better than being on top of them all the time.

## How Does This Help ***Gameplay***?

Immersion.

## How Does This Help ***Roleplay***?

Also immersion.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

![image](https://github.com/user-attachments/assets/5fb0f7c9-a95d-4fd2-8911-9cb3d4720181)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
fix: Railings now display properly.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
