### PR TITLE
Fix Borg Pref/Ban Not Working

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -260,7 +260,8 @@
 				return
 			// Special message for jobbans and prefs preventing borging.
 			if(is_banned_from(brainmob.ckey, JOB_CYBORG) || (brainmob.mind.assigned_role != /datum/job/cyborg && brainmob.client?.prefs && CONTENT_PREFERENCE_CHECK(brainmob.client.prefs.read_preference(/datum/preference/choiced/content/borging))))
-				to_chat(user, span_warning("This [M.name] seems to have incompatible firmware!"))
+				to_chat(user, span_warning("This [M.name] seems to have blacklisted firmware!"))
+				return
 			if(!user.temporarilyRemoveItemFromInventory(W))
 				return
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/content.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/content.tsx
@@ -15,7 +15,8 @@ export const content_brainwashing: Feature<string> = {
 
 export const content_borging: Feature<string> = {
   name: 'Borging',
-  description: 'Whether you want to be, or are fine with being borged.',
+  description:
+    'Whether you want to be, or are fine with being borged. Mechanically enforced.',
   component: FeatureDropdownInput,
 };
 
@@ -41,7 +42,7 @@ export const content_torture: Feature<string> = {
 export const content_death: Feature<string> = {
   name: 'Death',
   description:
-    'Whether you want to be, or are fine with being killed as part of an antag objective. Be aware that this does !!NOT!! protect antagonists from killing you as part of a broader plan, or in collateral. This just protects you from being explicitly labeled to be killed.',
+    'Whether you want to be, or are fine with being killed as part of an antag objective. Be aware that this does !!NOT!! protect antagonists from killing you as part of a broader plan, or in collateral. This just protects you from being a kill objective.',
   component: FeatureDropdownInput,
 };
 


### PR DESCRIPTION
## About The Pull Request

Tin, I forgor a return.

I also tweaked the message to be something that's a little more clear that the robo can't fix the problem, and made the pref declare that it's mechanically enforced.

Also also tweaked the wording of the death pref to be more clear that it's for objectives.

## How Does This Help ***Gameplay***?

Folk who shouldn't be borgs now won't be able to be borged, yay!

## How Does This Help ***Roleplay***?

Robos won't try to fix a problem they can't actually fix.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
<!-- New content PRs will not be merged without screencaps of what every added thing looks like in game. -->

<details>
<summary>Screenshots/Videos</summary> <!-- Leave the line after this one empty. Embeds like breaking if you don't -->

Later, I'm sleeping soon.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
qol: Borging and kill content preferences are now clear about what they affect.
fix: Borging preference now works. Woops.
/:cl:

<!-- Both :cl:s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
